### PR TITLE
release: Backend Privy accounts, wallets, and balance cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,5 +36,10 @@ ASSETS_CACHE_TTL_MS=300000
 PRIVY_APP_ID=
 # Public verification key from Privy dashboard. Use PEM or base64url DER SPKI.
 PRIVY_VERIFICATION_KEY=
+# Browser-safe comma-separated login methods exposed by /api/v1/public/auth-config.
+PRIVY_LOGIN_METHODS=email,google,apple,passkey
+# Browser-safe onboarding capability flags exposed by /api/v1/public/auth-config.
+PRIVY_EMBEDDED_WALLET_ENABLED=true
+EXTERNAL_WALLET_BINDING_ENABLED=true
 # Development only: set true to allow unsigned local JWT claim validation without signature verification.
 PRIVY_AUTH_DEV_ALLOW_UNSIGNED=false

--- a/db/migrations/20260622000100-add-account-lifecycle-fields.js
+++ b/db/migrations/20260622000100-add-account-lifecycle-fields.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('app_users', 'deleted_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('app_users', 'deletion_requested_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addColumn('app_users', 'deletion_available_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+    await queryInterface.addIndex('app_users', ['status']);
+    await queryInterface.addIndex('app_users', ['deletion_available_at']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('app_users', ['deletion_available_at']);
+    await queryInterface.removeIndex('app_users', ['status']);
+    await queryInterface.removeColumn('app_users', 'deletion_available_at');
+    await queryInterface.removeColumn('app_users', 'deletion_requested_at');
+    await queryInterface.removeColumn('app_users', 'deleted_at');
+  },
+};

--- a/db/migrations/20260622000200-add-wallet-link-binding-fields.js
+++ b/db/migrations/20260622000200-add-wallet-link-binding-fields.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('wallet_links', 'source', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'privy',
+    });
+    await queryInterface.addColumn('wallet_links', 'status', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'active',
+    });
+    await queryInterface.addColumn('wallet_links', 'deleted_at', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+
+    await queryInterface.addIndex('wallet_links', ['user_id', 'status']);
+    await queryInterface.addIndex('wallet_links', ['deleted_at']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('wallet_links', ['deleted_at']);
+    await queryInterface.removeIndex('wallet_links', ['user_id', 'status']);
+    await queryInterface.removeColumn('wallet_links', 'deleted_at');
+    await queryInterface.removeColumn('wallet_links', 'status');
+    await queryInterface.removeColumn('wallet_links', 'source');
+  },
+};

--- a/db/migrations/20260623000100-create-balance-cache-entries.js
+++ b/db/migrations/20260623000100-create-balance-cache-entries.js
@@ -1,0 +1,89 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.sequelize.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+
+    await queryInterface.createTable('balance_cache_entries', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('gen_random_uuid()'),
+        primaryKey: true,
+        allowNull: false,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'app_users', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      wallet_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'wallet_links', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      wallet_address: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      chain_type: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      asset_id: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      symbol: {
+        type: Sequelize.STRING,
+        allowNull: false,
+      },
+      decimals: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      balance_raw: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: '0',
+      },
+      balance_decimal: {
+        type: Sequelize.STRING,
+        allowNull: true,
+      },
+      source: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: 'postgres_cache',
+      },
+      fetched_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      expires_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.fn('NOW'),
+      },
+    });
+
+    await queryInterface.addIndex('balance_cache_entries', ['user_id']);
+    await queryInterface.addIndex('balance_cache_entries', ['wallet_id']);
+    await queryInterface.addIndex('balance_cache_entries', ['expires_at']);
+    await queryInterface.addIndex('balance_cache_entries', ['user_id', 'wallet_id', 'asset_id'], { unique: true });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('balance_cache_entries');
+  },
+};

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -5,8 +5,9 @@ import { QuotesModule } from './quotes/quotes.module';
 import { MarketsModule } from './markets/markets.module';
 import { SwapsModule } from '../modules/swaps';
 import { AuthModule } from './auth/auth.module';
+import { BalancesModule } from './balances/balances.module';
 
 @Module({
-    imports: [AuthModule, TranslationsModule, AssetsModule, QuotesModule, MarketsModule, SwapsModule],
+    imports: [AuthModule, TranslationsModule, AssetsModule, QuotesModule, MarketsModule, SwapsModule, BalancesModule],
 })
 export class ApiModule {}

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Post, Req, UseGuards } from '@nestjs/common';
 import type { Request } from 'express';
 import { PrivySessionDto } from './dto/privy-session.dto';
 import { CurrentUser } from './current-user.decorator';
@@ -53,6 +53,16 @@ export class AuthController {
     @UseGuards(PrivyAuthGuard)
     me(@CurrentUser() user: AuthenticatedUser) {
         return { user };
+    }
+
+    @Delete('me')
+    @UseGuards(PrivyAuthGuard)
+    async requestAccountDeletion(@CurrentUser() user: AuthenticatedUser) {
+        const result = await this.authService.requestAccountDeletion(user);
+        return {
+            status: 'pending_deletion',
+            deletionAvailableAt: result.deletionAvailableAt.toISOString(),
+        };
     }
 
     @Get('wallets')

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Delete, Get, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
 import type { Request } from 'express';
 import { PrivySessionDto } from './dto/privy-session.dto';
+import { BindWalletDto } from './dto/wallet-binding.dto';
 import { CurrentUser } from './current-user.decorator';
 import { PrivyAuthGuard } from './privy-auth.guard';
 import { PrivyAuthService } from './privy-auth.service';
@@ -24,7 +25,10 @@ function serializeWallet(wallet: {
     address: string;
     chainType: string;
     walletType: string;
+    source: string;
+    status: string;
     isPrimary: boolean;
+    deletedAt?: Date | null;
 }) {
     return {
         id: wallet.id,
@@ -32,7 +36,10 @@ function serializeWallet(wallet: {
         address: wallet.address,
         chainType: wallet.chainType,
         walletType: wallet.walletType,
+        source: wallet.source,
+        status: wallet.status,
         isPrimary: wallet.isPrimary,
+        deletedAt: wallet.deletedAt?.toISOString() ?? null,
     };
 }
 
@@ -70,5 +77,29 @@ export class AuthController {
     async wallets(@CurrentUser() user: AuthenticatedUser) {
         const wallets = await this.authService.walletsForUser(user.id);
         return { wallets: wallets.map(serializeWallet) };
+    }
+
+    @Post('wallets')
+    @UseGuards(PrivyAuthGuard)
+    async bindWallet(@CurrentUser() user: AuthenticatedUser, @Body() body: BindWalletDto) {
+        const wallet = await this.authService.bindWallet(user, body);
+        return { wallet: serializeWallet(wallet) };
+    }
+
+    @Patch('wallets/:walletId/primary')
+    @UseGuards(PrivyAuthGuard)
+    async setPrimaryWallet(@CurrentUser() user: AuthenticatedUser, @Param('walletId') walletId: string) {
+        const wallet = await this.authService.setPrimaryWallet(user, walletId);
+        return { wallet: serializeWallet(wallet) };
+    }
+
+    @Delete('wallets/:walletId')
+    @UseGuards(PrivyAuthGuard)
+    async deleteWallet(@CurrentUser() user: AuthenticatedUser, @Param('walletId') walletId: string) {
+        const result = await this.authService.deleteWallet(user, walletId);
+        return {
+            wallet: serializeWallet(result.wallet),
+            promotedWallet: result.promotedWallet ? serializeWallet(result.promotedWallet) : null,
+        };
     }
 }

--- a/src/api/auth/auth.module.ts
+++ b/src/api/auth/auth.module.ts
@@ -4,11 +4,13 @@ import { AuthController } from './auth.controller';
 import { PrivyAuthGuard } from './privy-auth.guard';
 import { PrivyAuthService } from './privy-auth.service';
 import { PrivyTokenService } from './privy-token.service';
+import { PublicAuthConfigController } from './public-auth-config.controller';
+import { PublicAuthConfigService } from './public-auth-config.service';
 
 @Module({
     imports: [DatabaseModule],
-    controllers: [AuthController],
-    providers: [PrivyAuthGuard, PrivyAuthService, PrivyTokenService],
+    controllers: [AuthController, PublicAuthConfigController],
+    providers: [PrivyAuthGuard, PrivyAuthService, PrivyTokenService, PublicAuthConfigService],
     exports: [PrivyAuthGuard, PrivyAuthService],
 })
 export class AuthModule {}

--- a/src/api/auth/dto/privy-session.dto.ts
+++ b/src/api/auth/dto/privy-session.dto.ts
@@ -1,23 +1,36 @@
 import { Type } from 'class-transformer';
-import { IsBoolean, IsEmail, IsOptional, IsString, Matches } from 'class-validator';
+import { IsBoolean, IsEmail, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
 import { ValidateNested } from 'class-validator';
+import {
+    SUPPORTED_WALLET_CHAIN_TYPES,
+    SUPPORTED_WALLET_SOURCES,
+    SUPPORTED_WALLET_TYPES,
+    WalletChainType,
+    WalletSource,
+    WalletType,
+} from './wallet-binding.dto';
 
 export class PrivyWalletDto {
     @IsOptional()
     @IsString()
+    @MaxLength(128)
     privyWalletId?: string;
 
     @IsString()
-    @Matches(/^0x[a-fA-F0-9]{40}$/)
+    @MaxLength(128)
     address: string;
 
     @IsOptional()
-    @IsString()
-    chainType?: string;
+    @IsIn(SUPPORTED_WALLET_CHAIN_TYPES)
+    chainType?: WalletChainType;
 
     @IsOptional()
-    @IsString()
-    walletType?: string;
+    @IsIn(SUPPORTED_WALLET_TYPES)
+    walletType?: WalletType;
+
+    @IsOptional()
+    @IsIn(SUPPORTED_WALLET_SOURCES)
+    source?: WalletSource;
 
     @IsOptional()
     @IsBoolean()

--- a/src/api/auth/dto/wallet-binding.dto.ts
+++ b/src/api/auth/dto/wallet-binding.dto.ts
@@ -1,0 +1,43 @@
+import { IsBoolean, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export const SUPPORTED_WALLET_CHAIN_TYPES = ['ethereum', 'evm', 'near'] as const;
+export const SUPPORTED_WALLET_TYPES = ['embedded', 'external'] as const;
+export const SUPPORTED_WALLET_SOURCES = [
+    'privy',
+    'metamask',
+    'walletconnect',
+    'coinbase',
+    'near',
+    'tonkeeper',
+] as const;
+
+export type WalletChainType = (typeof SUPPORTED_WALLET_CHAIN_TYPES)[number];
+export type WalletType = (typeof SUPPORTED_WALLET_TYPES)[number];
+export type WalletSource = (typeof SUPPORTED_WALLET_SOURCES)[number];
+
+export class BindWalletDto {
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    privyWalletId?: string;
+
+    @IsString()
+    @MaxLength(128)
+    address: string;
+
+    @IsOptional()
+    @IsIn(SUPPORTED_WALLET_CHAIN_TYPES)
+    chainType?: WalletChainType;
+
+    @IsOptional()
+    @IsIn(SUPPORTED_WALLET_TYPES)
+    walletType?: WalletType;
+
+    @IsOptional()
+    @IsIn(SUPPORTED_WALLET_SOURCES)
+    source?: WalletSource;
+
+    @IsOptional()
+    @IsBoolean()
+    isPrimary?: boolean;
+}

--- a/src/api/auth/privy-auth.service.spec.ts
+++ b/src/api/auth/privy-auth.service.spec.ts
@@ -1,0 +1,128 @@
+import { Sequelize } from 'sequelize-typescript';
+import { AuthAuditEvent } from '../../database/models/auth-audit-event.model';
+import { AppUser } from '../../database/models/app-user.model';
+import { WalletLink } from '../../database/models/wallet-link.model';
+import { PrivyAuthService } from './privy-auth.service';
+import { PrivyTokenService } from './privy-token.service';
+
+function tokenService() {
+    return {
+        verifyAccessToken: jest.fn(() => ({
+            sub: 'did:privy:user-1',
+            sid: 'session-1',
+            email: 'user@example.com',
+        })),
+    } as unknown as jest.Mocked<PrivyTokenService>;
+}
+
+describe('PrivyAuthService account lifecycle', () => {
+    let sequelize: Sequelize;
+    let service: PrivyAuthService;
+    let tokens: jest.Mocked<PrivyTokenService>;
+
+    beforeEach(async () => {
+        sequelize = new Sequelize({
+            dialect: 'sqlite',
+            storage: ':memory:',
+            logging: false,
+            models: [AppUser, WalletLink, AuthAuditEvent],
+        });
+        await sequelize.sync({ force: true });
+        tokens = tokenService();
+        service = new PrivyAuthService(sequelize, tokens);
+    });
+
+    afterEach(async () => {
+        await sequelize.close();
+    });
+
+    it('marks active accounts as pending deletion for 30 days', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+
+        const result = await service.requestAccountDeletion({
+            id: user.id,
+            privyUserId: user.privyUserId,
+            sessionId: 'session-1',
+        });
+
+        await user.reload();
+        expect(user.status).toBe('pending_deletion');
+        expect(user.deletionRequestedAt).toBeInstanceOf(Date);
+        expect(user.deletionAvailableAt?.toISOString()).toBe(result.deletionAvailableAt.toISOString());
+        expect(result.deletionAvailableAt.getTime() - user.deletionRequestedAt!.getTime()).toBe(
+            30 * 24 * 60 * 60 * 1000,
+        );
+
+        const event = await AuthAuditEvent.findOne({ where: { eventType: 'account.delete_requested' } });
+        expect(event?.userId).toBe(user.id);
+    });
+
+    it('restores pending-deletion accounts when the user signs in before the retention window expires', async () => {
+        const now = Date.now();
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'pending_deletion',
+            deletionRequestedAt: new Date(now - 24 * 60 * 60 * 1000),
+            deletionAvailableAt: new Date(now + 29 * 24 * 60 * 60 * 1000),
+        });
+
+        const result = await service.upsertSession('token', { authMethod: 'email' });
+
+        await user.reload();
+        expect(result.user.id).toBe(user.id);
+        expect(user.status).toBe('active');
+        expect(user.deletionRequestedAt).toBeNull();
+        expect(user.deletionAvailableAt).toBeNull();
+
+        const events = await AuthAuditEvent.findAll({ order: [['createdAt', 'ASC']] });
+        expect(events.map((event) => event.eventType)).toEqual(['account.restore', 'account.login']);
+    });
+
+    it('finalizes expired pending-deletion accounts before recreating the Privy subject', async () => {
+        const now = Date.now();
+        const oldUser = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'pending_deletion',
+            deletionRequestedAt: new Date(now - 31 * 24 * 60 * 60 * 1000),
+            deletionAvailableAt: new Date(now - 24 * 60 * 60 * 1000),
+        });
+
+        const result = await service.upsertSession('token', { authMethod: 'email' });
+
+        await oldUser.reload();
+        expect(oldUser.status).toBe('deleted');
+        expect(oldUser.deletedAt).toBeInstanceOf(Date);
+        expect(oldUser.privyUserId).toBe(`deleted:${oldUser.id}:did:privy:user-1`);
+        expect(result.user.id).not.toBe(oldUser.id);
+        expect(result.user.privyUserId).toBe('did:privy:user-1');
+
+        const events = await AuthAuditEvent.findAll({ order: [['createdAt', 'ASC']] });
+        expect(events.map((event) => event.eventType)).toEqual(['account.final_purge', 'account.signup']);
+    });
+
+    it('purges pending-deletion accounts whose retention window has elapsed', async () => {
+        const now = new Date('2026-06-22T12:00:00Z');
+        const eligible = await AppUser.create({
+            privyUserId: 'did:privy:eligible',
+            status: 'pending_deletion',
+            deletionRequestedAt: new Date('2026-05-01T12:00:00Z'),
+            deletionAvailableAt: new Date('2026-05-31T12:00:00Z'),
+        });
+        const retained = await AppUser.create({
+            privyUserId: 'did:privy:retained',
+            status: 'pending_deletion',
+            deletionRequestedAt: new Date('2026-06-01T12:00:00Z'),
+            deletionAvailableAt: new Date('2026-07-01T12:00:00Z'),
+        });
+
+        await expect(service.purgeDeletionEligibleAccounts(now)).resolves.toBe(1);
+
+        await eligible.reload();
+        await retained.reload();
+        expect(eligible.status).toBe('deleted');
+        expect(retained.status).toBe('pending_deletion');
+    });
+});

--- a/src/api/auth/privy-auth.service.spec.ts
+++ b/src/api/auth/privy-auth.service.spec.ts
@@ -125,4 +125,186 @@ describe('PrivyAuthService account lifecycle', () => {
         expect(eligible.status).toBe('deleted');
         expect(retained.status).toBe('pending_deletion');
     });
+
+    it('binds a wallet to the active account and records an audit event', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+
+        const wallet = await service.bindWallet(
+            {
+                id: user.id,
+                privyUserId: user.privyUserId,
+                sessionId: 'session-1',
+            },
+            {
+                address: '0xA000000000000000000000000000000000000001',
+                chainType: 'ethereum',
+                walletType: 'embedded',
+                source: 'privy',
+            },
+        );
+
+        expect(wallet.address).toBe('0xa000000000000000000000000000000000000001');
+        expect(wallet.status).toBe('active');
+        expect(wallet.isPrimary).toBe(true);
+
+        const event = await AuthAuditEvent.findOne({ where: { eventType: 'wallet.bind' } });
+        expect(event?.userId).toBe(user.id);
+        expect(event?.metadata).toMatchObject({
+            walletId: wallet.id,
+            address: wallet.address,
+        });
+    });
+
+    it('requires an explicit supported source for external wallet binding', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+
+        await expect(
+            service.bindWallet(
+                {
+                    id: user.id,
+                    privyUserId: user.privyUserId,
+                    sessionId: 'session-1',
+                },
+                {
+                    address: '0xA000000000000000000000000000000000000001',
+                    chainType: 'ethereum',
+                    walletType: 'external',
+                },
+            ),
+        ).rejects.toThrow('External wallet source is required');
+    });
+
+    it('switches the primary wallet without changing wallet ownership', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+        const first = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'first',
+            address: '0xa000000000000000000000000000000000000001',
+            chainType: 'ethereum',
+            walletType: 'embedded',
+            source: 'privy',
+            status: 'active',
+            isPrimary: true,
+        });
+        const second = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'second',
+            address: '0xa000000000000000000000000000000000000002',
+            chainType: 'ethereum',
+            walletType: 'external',
+            source: 'walletconnect',
+            status: 'active',
+            isPrimary: false,
+        });
+
+        const selected = await service.setPrimaryWallet(
+            {
+                id: user.id,
+                privyUserId: user.privyUserId,
+                sessionId: 'session-1',
+            },
+            second.id,
+        );
+
+        await first.reload();
+        await second.reload();
+        expect(selected.id).toBe(second.id);
+        expect(first.isPrimary).toBe(false);
+        expect(second.isPrimary).toBe(true);
+    });
+
+    it('soft-deletes a primary wallet and promotes the oldest remaining active wallet', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+        const first = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'first',
+            address: '0xa000000000000000000000000000000000000001',
+            chainType: 'ethereum',
+            walletType: 'embedded',
+            source: 'privy',
+            status: 'active',
+            isPrimary: true,
+        });
+        const second = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'second',
+            address: '0xa000000000000000000000000000000000000002',
+            chainType: 'ethereum',
+            walletType: 'external',
+            source: 'walletconnect',
+            status: 'active',
+            isPrimary: false,
+        });
+
+        const result = await service.deleteWallet(
+            {
+                id: user.id,
+                privyUserId: user.privyUserId,
+                sessionId: 'session-1',
+            },
+            first.id,
+        );
+
+        await first.reload();
+        await second.reload();
+        const visibleWallets = await service.walletsForUser(user.id);
+
+        expect(result.wallet.id).toBe(first.id);
+        expect(result.promotedWallet?.id).toBe(second.id);
+        expect(first.status).toBe('deleted');
+        expect(first.deletedAt).toBeInstanceOf(Date);
+        expect(first.isPrimary).toBe(false);
+        expect(second.isPrimary).toBe(true);
+        expect(visibleWallets.map((wallet) => wallet.id)).toEqual([second.id]);
+    });
+
+    it('reactivates a soft-deleted wallet link when the same address is rebound', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+        const deleted = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'first',
+            address: '0xa000000000000000000000000000000000000001',
+            chainType: 'ethereum',
+            walletType: 'embedded',
+            source: 'privy',
+            status: 'deleted',
+            isPrimary: false,
+            deletedAt: new Date('2026-06-22T12:00:00Z'),
+        });
+
+        const rebound = await service.bindWallet(
+            {
+                id: user.id,
+                privyUserId: user.privyUserId,
+                sessionId: 'session-1',
+            },
+            {
+                address: '0xA000000000000000000000000000000000000001',
+                chainType: 'ethereum',
+                walletType: 'embedded',
+                isPrimary: true,
+            },
+        );
+
+        await deleted.reload();
+        expect(rebound.id).toBe(deleted.id);
+        expect(deleted.status).toBe('active');
+        expect(deleted.deletedAt).toBeNull();
+        expect(deleted.isPrimary).toBe(true);
+    });
 });

--- a/src/api/auth/privy-auth.service.ts
+++ b/src/api/auth/privy-auth.service.ts
@@ -1,4 +1,11 @@
-import { ForbiddenException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+    BadRequestException,
+    ForbiddenException,
+    Inject,
+    Injectable,
+    NotFoundException,
+    UnauthorizedException,
+} from '@nestjs/common';
 import { Op, Transaction } from 'sequelize';
 import { Sequelize } from 'sequelize-typescript';
 import { AuthAuditEvent } from '../../database/models/auth-audit-event.model';
@@ -6,6 +13,7 @@ import { AppUser } from '../../database/models/app-user.model';
 import { WalletLink } from '../../database/models/wallet-link.model';
 import { SEQUELIZE } from '../../database/database.tokens';
 import { PrivySessionDto, PrivyWalletDto } from './dto/privy-session.dto';
+import { BindWalletDto, WalletSource, WalletType } from './dto/wallet-binding.dto';
 import { PrivyTokenService } from './privy-token.service';
 import type { AuthenticatedUser } from './types';
 
@@ -101,7 +109,7 @@ export class PrivyAuthService {
             );
 
             const wallets = await WalletLink.findAll({
-                where: { userId: user.id },
+                where: { userId: user.id, status: 'active' },
                 order: [
                     ['isPrimary', 'DESC'],
                     ['createdAt', 'ASC'],
@@ -124,11 +132,112 @@ export class PrivyAuthService {
 
     async walletsForUser(userId: string): Promise<WalletLink[]> {
         return WalletLink.findAll({
-            where: { userId },
+            where: { userId, status: 'active' },
             order: [
                 ['isPrimary', 'DESC'],
                 ['createdAt', 'ASC'],
             ],
+        });
+    }
+
+    async bindWallet(user: AuthenticatedUser, body: BindWalletDto): Promise<WalletLink> {
+        return this.sequelize.transaction(async (transaction) => {
+            await this.assertActiveUser(user.id, transaction);
+
+            const wallet = await this.upsertWallet(user.id, body, transaction);
+            await AuthAuditEvent.create(
+                {
+                    userId: user.id,
+                    privyUserId: user.privyUserId,
+                    eventType: 'wallet.bind',
+                    metadata: {
+                        walletId: wallet.id,
+                        address: wallet.address,
+                        chainType: wallet.chainType,
+                        walletType: wallet.walletType,
+                        source: wallet.source,
+                    },
+                },
+                { transaction },
+            );
+
+            return wallet;
+        });
+    }
+
+    async setPrimaryWallet(user: AuthenticatedUser, walletId: string): Promise<WalletLink> {
+        return this.sequelize.transaction(async (transaction) => {
+            await this.assertActiveUser(user.id, transaction);
+            const wallet = await this.findActiveWallet(user.id, walletId, transaction);
+
+            await this.markPrimaryWallet(user.id, wallet.id, transaction);
+            await AuthAuditEvent.create(
+                {
+                    userId: user.id,
+                    privyUserId: user.privyUserId,
+                    eventType: 'wallet.set_primary',
+                    metadata: {
+                        walletId: wallet.id,
+                        address: wallet.address,
+                    },
+                },
+                { transaction },
+            );
+
+            await wallet.reload({ transaction });
+            return wallet;
+        });
+    }
+
+    async deleteWallet(
+        user: AuthenticatedUser,
+        walletId: string,
+    ): Promise<{ wallet: WalletLink; promotedWallet?: WalletLink }> {
+        return this.sequelize.transaction(async (transaction) => {
+            await this.assertActiveUser(user.id, transaction);
+            const wallet = await this.findActiveWallet(user.id, walletId, transaction);
+            const wasPrimary = wallet.isPrimary;
+            const now = new Date();
+
+            await wallet.update(
+                {
+                    status: 'deleted',
+                    deletedAt: now,
+                    isPrimary: false,
+                },
+                { transaction },
+            );
+
+            let promotedWallet: WalletLink | undefined;
+            if (wasPrimary) {
+                promotedWallet = await WalletLink.findOne({
+                    where: { userId: user.id, status: 'active' },
+                    order: [['createdAt', 'ASC']],
+                    transaction,
+                });
+
+                if (promotedWallet) {
+                    await this.markPrimaryWallet(user.id, promotedWallet.id, transaction);
+                    await promotedWallet.reload({ transaction });
+                }
+            }
+
+            await AuthAuditEvent.create(
+                {
+                    userId: user.id,
+                    privyUserId: user.privyUserId,
+                    eventType: 'wallet.delete',
+                    metadata: {
+                        walletId: wallet.id,
+                        address: wallet.address,
+                        deletedAt: now.toISOString(),
+                        promotedWalletId: promotedWallet?.id,
+                    },
+                },
+                { transaction },
+            );
+
+            return { wallet, promotedWallet };
         });
     }
 
@@ -186,16 +295,26 @@ export class PrivyAuthService {
         return users.length;
     }
 
-    private async upsertWallet(userId: string, wallet: PrivyWalletDto, transaction: Transaction): Promise<void> {
-        const address = wallet.address.toLowerCase();
+    private async upsertWallet(
+        userId: string,
+        wallet: PrivyWalletDto | BindWalletDto,
+        transaction: Transaction,
+    ): Promise<WalletLink> {
+        const chainType = wallet.chainType || 'ethereum';
+        const walletType = wallet.walletType || 'embedded';
+        const source = this.resolveWalletSource(walletType, wallet.source);
+        const address = this.normalizeWalletAddress(wallet.address, chainType);
         const [walletLink] = await WalletLink.findOrCreate({
             where: { userId, address },
             defaults: {
                 userId,
                 address,
                 privyWalletId: wallet.privyWalletId || address,
-                chainType: wallet.chainType || 'ethereum',
-                walletType: wallet.walletType || 'embedded',
+                chainType,
+                walletType,
+                source,
+                status: 'active',
+                deletedAt: null,
                 isPrimary: wallet.isPrimary ?? true,
             },
             transaction,
@@ -204,12 +323,90 @@ export class PrivyAuthService {
         await walletLink.update(
             {
                 privyWalletId: wallet.privyWalletId || walletLink.privyWalletId,
-                chainType: wallet.chainType || walletLink.chainType,
-                walletType: wallet.walletType || walletLink.walletType,
+                chainType,
+                walletType,
+                source,
+                status: 'active',
+                deletedAt: null,
                 isPrimary: wallet.isPrimary ?? walletLink.isPrimary,
             },
             { transaction },
         );
+
+        if (walletLink.isPrimary) {
+            await this.markPrimaryWallet(userId, walletLink.id, transaction);
+            await walletLink.reload({ transaction });
+        }
+
+        return walletLink;
+    }
+
+    private async assertActiveUser(userId: string, transaction: Transaction): Promise<void> {
+        const appUser = await AppUser.findByPk(userId, { transaction });
+        if (!appUser || appUser.status !== 'active') {
+            throw new UnauthorizedException('Authenticated Privy user is not active');
+        }
+    }
+
+    private async findActiveWallet(userId: string, walletId: string, transaction: Transaction): Promise<WalletLink> {
+        const wallet = await WalletLink.findOne({
+            where: {
+                id: walletId,
+                userId,
+                status: 'active',
+            },
+            transaction,
+        });
+
+        if (!wallet) {
+            throw new NotFoundException('Wallet link not found');
+        }
+
+        return wallet;
+    }
+
+    private async markPrimaryWallet(userId: string, walletId: string, transaction: Transaction): Promise<void> {
+        await WalletLink.update({ isPrimary: false }, { where: { userId, status: 'active' }, transaction });
+        await WalletLink.update(
+            { isPrimary: true },
+            { where: { id: walletId, userId, status: 'active' }, transaction },
+        );
+    }
+
+    private normalizeWalletAddress(address: string, chainType: string): string {
+        const value = address.trim();
+        if (!value) {
+            throw new BadRequestException('Wallet address is required');
+        }
+
+        if (chainType === 'ethereum' || chainType === 'evm') {
+            if (!/^0x[a-fA-F0-9]{40}$/.test(value)) {
+                throw new BadRequestException('EVM wallet address must be a 20-byte hex address');
+            }
+            return value.toLowerCase();
+        }
+
+        if (chainType === 'near') {
+            const normalized = value.toLowerCase();
+            if (!/^(([a-z0-9]+[-_])*[a-z0-9]+[.])*([a-z0-9]+[-_])*[a-z0-9]+$/.test(normalized)) {
+                throw new BadRequestException('NEAR wallet address must be a valid account id');
+            }
+            return normalized;
+        }
+
+        throw new BadRequestException('Unsupported wallet chain type');
+    }
+
+    private resolveWalletSource(walletType: WalletType, source?: WalletSource): WalletSource {
+        if (source) {
+            return source;
+        }
+
+        if (walletType === 'embedded') {
+            return 'privy';
+        }
+
+        throw new BadRequestException('External wallet source is required');
     }
 
     private deletionWindowExpired(user: AppUser, now: Date): boolean {

--- a/src/api/auth/privy-auth.service.ts
+++ b/src/api/auth/privy-auth.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Op, Transaction } from 'sequelize';
 import { Sequelize } from 'sequelize-typescript';
 import { AuthAuditEvent } from '../../database/models/auth-audit-event.model';
 import { AppUser } from '../../database/models/app-user.model';
@@ -7,6 +8,8 @@ import { SEQUELIZE } from '../../database/database.tokens';
 import { PrivySessionDto, PrivyWalletDto } from './dto/privy-session.dto';
 import { PrivyTokenService } from './privy-token.service';
 import type { AuthenticatedUser } from './types';
+
+const SOFT_DELETE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class PrivyAuthService {
@@ -38,8 +41,24 @@ export class PrivyAuthService {
     ): Promise<{ user: AuthenticatedUser; wallets: WalletLink[] }> {
         const claims = this.tokenService.verifyAccessToken(accessToken);
 
-        return this.sequelize.transaction(async () => {
-            const [user] = await AppUser.findOrCreate({
+        return this.sequelize.transaction(async (transaction) => {
+            const now = new Date();
+            let user = await AppUser.findOne({ where: { privyUserId: claims.sub }, transaction });
+
+            if (user?.status === 'deleted') {
+                throw new ForbiddenException('Privy account is deleted');
+            }
+
+            if (user?.status === 'pending_deletion') {
+                if (this.deletionWindowExpired(user, now)) {
+                    await this.finalizeDeletedUser(user, now, transaction);
+                    user = null;
+                } else {
+                    await this.restorePendingDeletion(user, now, transaction);
+                }
+            }
+
+            const [activeUser, created] = await AppUser.findOrCreate({
                 where: { privyUserId: claims.sub },
                 defaults: {
                     privyUserId: claims.sub,
@@ -47,28 +66,39 @@ export class PrivyAuthService {
                     authMethod: body.authMethod || null,
                     status: 'active',
                 },
+                transaction,
             });
+            user = activeUser;
 
-            await user.update({
-                email: body.email || claims.email || user.email || null,
-                authMethod: body.authMethod || user.authMethod || null,
-                status: 'active',
-            });
+            await user.update(
+                {
+                    email: body.email || claims.email || user.email || null,
+                    authMethod: body.authMethod || user.authMethod || null,
+                    status: 'active',
+                    deletedAt: null,
+                    deletionRequestedAt: null,
+                    deletionAvailableAt: null,
+                },
+                { transaction },
+            );
 
             if (body.wallet) {
-                await this.upsertWallet(user.id, body.wallet);
+                await this.upsertWallet(user.id, body.wallet, transaction);
             }
 
-            await AuthAuditEvent.create({
-                userId: user.id,
-                privyUserId: user.privyUserId,
-                eventType: 'privy.session.upserted',
-                metadata: {
-                    sessionId: claims.sid,
-                    walletAddress: body.wallet?.address,
-                    authMethod: body.authMethod,
+            await AuthAuditEvent.create(
+                {
+                    userId: user.id,
+                    privyUserId: user.privyUserId,
+                    eventType: created ? 'account.signup' : 'account.login',
+                    metadata: {
+                        sessionId: claims.sid,
+                        walletAddress: body.wallet?.address,
+                        authMethod: body.authMethod,
+                    },
                 },
-            });
+                { transaction },
+            );
 
             const wallets = await WalletLink.findAll({
                 where: { userId: user.id },
@@ -76,6 +106,7 @@ export class PrivyAuthService {
                     ['isPrimary', 'DESC'],
                     ['createdAt', 'ASC'],
                 ],
+                transaction,
             });
 
             return {
@@ -101,7 +132,61 @@ export class PrivyAuthService {
         });
     }
 
-    private async upsertWallet(userId: string, wallet: PrivyWalletDto): Promise<void> {
+    async requestAccountDeletion(user: AuthenticatedUser): Promise<{ deletionAvailableAt: Date }> {
+        return this.sequelize.transaction(async (transaction) => {
+            const appUser = await AppUser.findByPk(user.id, { transaction });
+            if (!appUser || appUser.status !== 'active') {
+                throw new UnauthorizedException('Authenticated Privy user is not active');
+            }
+
+            const now = new Date();
+            const deletionAvailableAt = new Date(now.getTime() + SOFT_DELETE_RETENTION_MS);
+            await appUser.update(
+                {
+                    status: 'pending_deletion',
+                    deletionRequestedAt: now,
+                    deletionAvailableAt,
+                    deletedAt: null,
+                },
+                { transaction },
+            );
+
+            await AuthAuditEvent.create(
+                {
+                    userId: appUser.id,
+                    privyUserId: appUser.privyUserId,
+                    eventType: 'account.delete_requested',
+                    metadata: {
+                        deletionAvailableAt: deletionAvailableAt.toISOString(),
+                    },
+                },
+                { transaction },
+            );
+
+            return { deletionAvailableAt };
+        });
+    }
+
+    async purgeDeletionEligibleAccounts(now = new Date()): Promise<number> {
+        const users = await AppUser.findAll({
+            where: {
+                status: 'pending_deletion',
+                deletionAvailableAt: {
+                    [Op.lte]: now,
+                },
+            },
+        });
+
+        for (const user of users) {
+            await this.sequelize.transaction(async (transaction) => {
+                await this.finalizeDeletedUser(user, now, transaction);
+            });
+        }
+
+        return users.length;
+    }
+
+    private async upsertWallet(userId: string, wallet: PrivyWalletDto, transaction: Transaction): Promise<void> {
         const address = wallet.address.toLowerCase();
         const [walletLink] = await WalletLink.findOrCreate({
             where: { userId, address },
@@ -113,13 +198,69 @@ export class PrivyAuthService {
                 walletType: wallet.walletType || 'embedded',
                 isPrimary: wallet.isPrimary ?? true,
             },
+            transaction,
         });
 
-        await walletLink.update({
-            privyWalletId: wallet.privyWalletId || walletLink.privyWalletId,
-            chainType: wallet.chainType || walletLink.chainType,
-            walletType: wallet.walletType || walletLink.walletType,
-            isPrimary: wallet.isPrimary ?? walletLink.isPrimary,
-        });
+        await walletLink.update(
+            {
+                privyWalletId: wallet.privyWalletId || walletLink.privyWalletId,
+                chainType: wallet.chainType || walletLink.chainType,
+                walletType: wallet.walletType || walletLink.walletType,
+                isPrimary: wallet.isPrimary ?? walletLink.isPrimary,
+            },
+            { transaction },
+        );
+    }
+
+    private deletionWindowExpired(user: AppUser, now: Date): boolean {
+        return Boolean(user.deletionAvailableAt && user.deletionAvailableAt.getTime() <= now.getTime());
+    }
+
+    private async restorePendingDeletion(user: AppUser, now: Date, transaction: Transaction): Promise<void> {
+        await user.update(
+            {
+                status: 'active',
+                deletedAt: null,
+                deletionRequestedAt: null,
+                deletionAvailableAt: null,
+            },
+            { transaction },
+        );
+
+        await AuthAuditEvent.create(
+            {
+                userId: user.id,
+                privyUserId: user.privyUserId,
+                eventType: 'account.restore',
+                metadata: {
+                    restoredAt: now.toISOString(),
+                },
+            },
+            { transaction },
+        );
+    }
+
+    private async finalizeDeletedUser(user: AppUser, now: Date, transaction: Transaction): Promise<void> {
+        const previousPrivyUserId = user.privyUserId;
+        await user.update(
+            {
+                privyUserId: `deleted:${user.id}:${previousPrivyUserId}`,
+                status: 'deleted',
+                deletedAt: now,
+            },
+            { transaction },
+        );
+
+        await AuthAuditEvent.create(
+            {
+                userId: user.id,
+                privyUserId: previousPrivyUserId,
+                eventType: 'account.final_purge',
+                metadata: {
+                    deletedAt: now.toISOString(),
+                },
+            },
+            { transaction },
+        );
     }
 }

--- a/src/api/auth/public-auth-config.controller.ts
+++ b/src/api/auth/public-auth-config.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { PublicAuthConfigService } from './public-auth-config.service';
+
+@Controller({ version: '1', path: 'public/auth-config' })
+export class PublicAuthConfigController {
+    constructor(private readonly publicAuthConfigService: PublicAuthConfigService) {}
+
+    @Get()
+    getConfig() {
+        return this.publicAuthConfigService.getConfig();
+    }
+}

--- a/src/api/auth/public-auth-config.service.spec.ts
+++ b/src/api/auth/public-auth-config.service.spec.ts
@@ -1,0 +1,61 @@
+import { ConfigService } from '@nestjs/config';
+import { PublicAuthConfigService } from './public-auth-config.service';
+
+function service(values: Record<string, string | undefined>) {
+    return new PublicAuthConfigService(new ConfigService(values));
+}
+
+describe('PublicAuthConfigService', () => {
+    it('returns disabled public config when Privy app id is not configured', () => {
+        expect(service({}).getConfig()).toEqual({
+            privyAppId: null,
+            loginMethods: [],
+            walletOnboarding: {
+                embeddedWallet: false,
+                externalWalletBinding: false,
+            },
+        });
+    });
+
+    it('returns default public auth capabilities when Privy app id is configured', () => {
+        expect(service({ PRIVY_APP_ID: 'privy-app-id' }).getConfig()).toEqual({
+            privyAppId: 'privy-app-id',
+            loginMethods: ['email', 'google', 'apple', 'passkey'],
+            walletOnboarding: {
+                embeddedWallet: true,
+                externalWalletBinding: true,
+            },
+        });
+    });
+
+    it('filters configured login methods to supported public methods', () => {
+        expect(
+            service({
+                PRIVY_APP_ID: 'privy-app-id',
+                PRIVY_LOGIN_METHODS: 'email, google, unsupported, passkey',
+            }).getConfig().loginMethods,
+        ).toEqual(['email', 'google', 'passkey']);
+    });
+
+    it('supports disabling wallet onboarding capabilities independently', () => {
+        expect(
+            service({
+                PRIVY_APP_ID: 'privy-app-id',
+                PRIVY_EMBEDDED_WALLET_ENABLED: 'false',
+                EXTERNAL_WALLET_BINDING_ENABLED: '0',
+            }).getConfig().walletOnboarding,
+        ).toEqual({
+            embeddedWallet: false,
+            externalWalletBinding: false,
+        });
+    });
+
+    it('does not expose server-only Privy verification config', () => {
+        expect(
+            service({
+                PRIVY_APP_ID: 'privy-app-id',
+                PRIVY_VERIFICATION_KEY: 'server-only-key',
+            }).getConfig(),
+        ).not.toHaveProperty('privyVerificationKey');
+    });
+});

--- a/src/api/auth/public-auth-config.service.ts
+++ b/src/api/auth/public-auth-config.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+const SUPPORTED_LOGIN_METHODS = ['email', 'google', 'apple', 'passkey'] as const;
+
+export type PublicAuthLoginMethod = (typeof SUPPORTED_LOGIN_METHODS)[number];
+
+export type PublicAuthConfig = {
+    privyAppId: string | null;
+    loginMethods: PublicAuthLoginMethod[];
+    walletOnboarding: {
+        embeddedWallet: boolean;
+        externalWalletBinding: boolean;
+    };
+};
+
+@Injectable()
+export class PublicAuthConfigService {
+    constructor(private readonly config: ConfigService) {}
+
+    getConfig(): PublicAuthConfig {
+        const privyAppId = this.optionalString('PRIVY_APP_ID');
+        const privyEnabled = Boolean(privyAppId);
+
+        return {
+            privyAppId: privyAppId ?? null,
+            loginMethods: privyEnabled ? this.loginMethods() : [],
+            walletOnboarding: {
+                embeddedWallet: privyEnabled && this.booleanFlag('PRIVY_EMBEDDED_WALLET_ENABLED', true),
+                externalWalletBinding: privyEnabled && this.booleanFlag('EXTERNAL_WALLET_BINDING_ENABLED', true),
+            },
+        };
+    }
+
+    private loginMethods(): PublicAuthLoginMethod[] {
+        const configured = this.optionalString('PRIVY_LOGIN_METHODS');
+        if (!configured) {
+            return [...SUPPORTED_LOGIN_METHODS];
+        }
+
+        const configuredMethods = configured
+            .split(',')
+            .map((method) => method.trim().toLowerCase())
+            .filter(isSupportedLoginMethod);
+
+        return configuredMethods.length > 0 ? configuredMethods : [...SUPPORTED_LOGIN_METHODS];
+    }
+
+    private booleanFlag(name: string, defaultValue: boolean): boolean {
+        const value = this.optionalString(name);
+        if (value === undefined) {
+            return defaultValue;
+        }
+        return ['1', 'true', 'yes', 'on'].includes(value.toLowerCase());
+    }
+
+    private optionalString(name: string): string | undefined {
+        const value = this.config.get<string>(name);
+        const normalized = value?.trim();
+        return normalized || undefined;
+    }
+}
+
+function isSupportedLoginMethod(value: string): value is PublicAuthLoginMethod {
+    return SUPPORTED_LOGIN_METHODS.some((method) => method === value);
+}

--- a/src/api/balances/balances.controller.ts
+++ b/src/api/balances/balances.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { PrivyAuthGuard } from '../auth/privy-auth.guard';
+import type { AuthenticatedUser } from '../auth/types';
+import { BalancesService } from './balances.service';
+import { GetBalancesQueryDto } from './dto/get-balances-query.dto';
+import { GetBalancesResponseDto } from './dto/get-balances-response.dto';
+
+@ApiTags('balances')
+@ApiBearerAuth()
+@Controller({ version: '1', path: 'balances' })
+@UseGuards(PrivyAuthGuard)
+export class BalancesController {
+    constructor(private readonly balancesService: BalancesService) {}
+
+    @Get()
+    @ApiOkResponse({ type: GetBalancesResponseDto })
+    getBalances(@CurrentUser() user: AuthenticatedUser, @Query() query: GetBalancesQueryDto) {
+        return this.balancesService.getBalances(user, query);
+    }
+}

--- a/src/api/balances/balances.module.ts
+++ b/src/api/balances/balances.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AssetsModule } from '../assets/assets.module';
+import { AuthModule } from '../auth/auth.module';
+import { DatabaseModule } from '../../database/database.module';
+import { BalancesController } from './balances.controller';
+import { BalancesService } from './balances.service';
+
+@Module({
+    imports: [AuthModule, AssetsModule, DatabaseModule],
+    controllers: [BalancesController],
+    providers: [BalancesService],
+})
+export class BalancesModule {}

--- a/src/api/balances/balances.service.spec.ts
+++ b/src/api/balances/balances.service.spec.ts
@@ -1,0 +1,163 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Sequelize } from 'sequelize-typescript';
+import { AssetsService } from '../assets/assets.service';
+import { AssetDto } from '../assets/dto/get-assets-response.dto';
+import { AppUser } from '../../database/models/app-user.model';
+import { BalanceCacheEntry } from '../../database/models/balance-cache-entry.model';
+import { WalletLink } from '../../database/models/wallet-link.model';
+import { BalancesService } from './balances.service';
+
+const asset: AssetDto = {
+    assetId: 'nep141:usdc.near',
+    defuseAssetId: 'nep141:usdc.near',
+    symbol: 'USDC',
+    decimals: 6,
+    blockchain: 'near',
+};
+
+function assetsService(): jest.Mocked<Pick<AssetsService, 'findAssetById'>> {
+    return {
+        findAssetById: jest.fn(async (assetId: string) => (assetId === asset.assetId ? asset : undefined)),
+    };
+}
+
+describe('BalancesService', () => {
+    let sequelize: Sequelize;
+    let service: BalancesService;
+    let assets: jest.Mocked<Pick<AssetsService, 'findAssetById'>>;
+
+    beforeEach(async () => {
+        sequelize = new Sequelize({
+            dialect: 'sqlite',
+            storage: ':memory:',
+            logging: false,
+            models: [AppUser, WalletLink, BalanceCacheEntry],
+        });
+        await sequelize.sync({ force: true });
+
+        assets = assetsService();
+        service = new BalancesService(assets as unknown as AssetsService);
+    });
+
+    afterEach(async () => {
+        await sequelize.close();
+    });
+
+    it('returns valid cached balances for active wallets owned by the authenticated user', async () => {
+        const user = await AppUser.create({ privyUserId: 'did:privy:user-1', status: 'active' });
+        const wallet = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'wallet-1',
+            address: '0xa000000000000000000000000000000000000001',
+            chainType: 'near',
+            walletType: 'embedded',
+            source: 'privy',
+            status: 'active',
+            isPrimary: true,
+        });
+        await BalanceCacheEntry.create({
+            userId: user.id,
+            walletId: wallet.id,
+            walletAddress: wallet.address,
+            chainType: wallet.chainType,
+            assetId: asset.assetId,
+            symbol: asset.symbol,
+            decimals: asset.decimals,
+            balanceRaw: '1250000',
+            balanceDecimal: '1.25',
+            source: 'near_rpc',
+            fetchedAt: new Date(Date.now() - 1000),
+            expiresAt: new Date(Date.now() + 60000),
+        });
+
+        const result = await service.getBalances(
+            { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+            {},
+        );
+
+        expect(result.data).toEqual([
+            {
+                walletId: wallet.id,
+                walletAddress: wallet.address,
+                chainType: 'near',
+                assetId: asset.assetId,
+                symbol: 'USDC',
+                decimals: 6,
+                balanceRaw: '1250000',
+                balanceDecimal: '1.25',
+                source: 'near_rpc',
+                fetchedAt: expect.any(String),
+                expiresAt: expect.any(String),
+            },
+        ]);
+        expect(result.meta.source).toBe('postgres_cache');
+        expect(result.meta.cached).toBe(true);
+    });
+
+    it('does not return expired cache entries', async () => {
+        const user = await AppUser.create({ privyUserId: 'did:privy:user-1', status: 'active' });
+        const wallet = await WalletLink.create({
+            userId: user.id,
+            privyWalletId: 'wallet-1',
+            address: '0xa000000000000000000000000000000000000001',
+            chainType: 'near',
+            walletType: 'embedded',
+            source: 'privy',
+            status: 'active',
+            isPrimary: true,
+        });
+        await BalanceCacheEntry.create({
+            userId: user.id,
+            walletId: wallet.id,
+            walletAddress: wallet.address,
+            chainType: wallet.chainType,
+            assetId: asset.assetId,
+            symbol: asset.symbol,
+            decimals: asset.decimals,
+            balanceRaw: '1250000',
+            balanceDecimal: '1.25',
+            fetchedAt: new Date(Date.now() - 120000),
+            expiresAt: new Date(Date.now() - 60000),
+        });
+
+        const result = await service.getBalances(
+            { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+            {},
+        );
+
+        expect(result.data).toEqual([]);
+    });
+
+    it('rejects balances for wallets not owned by the authenticated user', async () => {
+        const user = await AppUser.create({ privyUserId: 'did:privy:user-1', status: 'active' });
+        const otherUser = await AppUser.create({ privyUserId: 'did:privy:user-2', status: 'active' });
+        const otherWallet = await WalletLink.create({
+            userId: otherUser.id,
+            privyWalletId: 'wallet-2',
+            address: '0xa000000000000000000000000000000000000002',
+            chainType: 'near',
+            walletType: 'embedded',
+            source: 'privy',
+            status: 'active',
+            isPrimary: true,
+        });
+
+        await expect(
+            service.getBalances(
+                { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+                { walletId: otherWallet.id },
+            ),
+        ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('rejects unsupported asset filters', async () => {
+        const user = await AppUser.create({ privyUserId: 'did:privy:user-1', status: 'active' });
+
+        await expect(
+            service.getBalances(
+                { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+                { assetId: 'unsupported' },
+            ),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+});

--- a/src/api/balances/balances.service.ts
+++ b/src/api/balances/balances.service.ts
@@ -1,0 +1,95 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Op } from 'sequelize';
+import { AssetDto } from '../assets/dto/get-assets-response.dto';
+import { AssetsService } from '../assets/assets.service';
+import { BalanceCacheEntry } from '../../database/models/balance-cache-entry.model';
+import { WalletLink } from '../../database/models/wallet-link.model';
+import type { AuthenticatedUser } from '../auth/types';
+import { GetBalancesQueryDto } from './dto/get-balances-query.dto';
+import { BalanceDto, GetBalancesResponseDto } from './dto/get-balances-response.dto';
+
+@Injectable()
+export class BalancesService {
+    constructor(private readonly assetsService: AssetsService) {}
+
+    async getBalances(user: AuthenticatedUser, query: GetBalancesQueryDto): Promise<GetBalancesResponseDto> {
+        const now = new Date();
+        const wallets = await this.findWallets(user.id, query.walletId);
+        const asset = query.assetId ? await this.findSupportedAsset(query.assetId) : undefined;
+
+        if (wallets.length === 0) {
+            return this.toResponse([], now);
+        }
+
+        const entries = await BalanceCacheEntry.findAll({
+            where: {
+                userId: user.id,
+                walletId: { [Op.in]: wallets.map((wallet) => wallet.id) },
+                ...(asset ? { assetId: asset.assetId } : {}),
+                expiresAt: { [Op.gt]: now },
+            },
+            order: [
+                ['walletId', 'ASC'],
+                ['assetId', 'ASC'],
+            ],
+        });
+
+        return this.toResponse(
+            entries.map((entry) => this.toDto(entry)),
+            now,
+        );
+    }
+
+    private async findWallets(userId: string, walletId?: string): Promise<WalletLink[]> {
+        if (walletId) {
+            const wallet = await WalletLink.findOne({ where: { id: walletId, userId, status: 'active' } });
+            if (!wallet) {
+                throw new NotFoundException('Wallet not found');
+            }
+            return [wallet];
+        }
+
+        return WalletLink.findAll({
+            where: { userId, status: 'active' },
+            order: [
+                ['isPrimary', 'DESC'],
+                ['createdAt', 'ASC'],
+            ],
+        });
+    }
+
+    private async findSupportedAsset(assetId: string): Promise<AssetDto> {
+        const asset = await this.assetsService.findAssetById(assetId);
+        if (!asset) {
+            throw new BadRequestException('Unsupported asset');
+        }
+        return asset;
+    }
+
+    private toDto(entry: BalanceCacheEntry): BalanceDto {
+        return {
+            walletId: entry.walletId,
+            walletAddress: entry.walletAddress,
+            chainType: entry.chainType,
+            assetId: entry.assetId,
+            symbol: entry.symbol,
+            decimals: entry.decimals,
+            balanceRaw: entry.balanceRaw,
+            balanceDecimal: entry.balanceDecimal ?? null,
+            source: entry.source,
+            fetchedAt: entry.fetchedAt.toISOString(),
+            expiresAt: entry.expiresAt.toISOString(),
+        };
+    }
+
+    private toResponse(data: BalanceDto[], now: Date): GetBalancesResponseDto {
+        return {
+            data,
+            meta: {
+                source: 'postgres_cache',
+                cached: true,
+                fetchedAt: now.toISOString(),
+            },
+        };
+    }
+}

--- a/src/api/balances/dto/get-balances-query.dto.ts
+++ b/src/api/balances/dto/get-balances-query.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+
+export class GetBalancesQueryDto {
+    @ApiPropertyOptional({ description: 'Restrict balances to one active wallet owned by the authenticated user.' })
+    @IsOptional()
+    @IsUUID()
+    walletId?: string;
+
+    @ApiPropertyOptional({ description: 'Restrict balances to one backend-supported asset id.' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(256)
+    assetId?: string;
+}

--- a/src/api/balances/dto/get-balances-response.dto.ts
+++ b/src/api/balances/dto/get-balances-response.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class BalanceDto {
+    @ApiProperty()
+    walletId: string;
+
+    @ApiProperty()
+    walletAddress: string;
+
+    @ApiProperty()
+    chainType: string;
+
+    @ApiProperty()
+    assetId: string;
+
+    @ApiProperty()
+    symbol: string;
+
+    @ApiProperty()
+    decimals: number;
+
+    @ApiProperty()
+    balanceRaw: string;
+
+    @ApiPropertyOptional()
+    balanceDecimal?: string | null;
+
+    @ApiProperty()
+    source: string;
+
+    @ApiProperty()
+    fetchedAt: string;
+
+    @ApiProperty()
+    expiresAt: string;
+}
+
+export class BalancesMetaDto {
+    @ApiProperty({ enum: ['postgres_cache'] })
+    source: 'postgres_cache';
+
+    @ApiProperty()
+    cached: boolean;
+
+    @ApiProperty()
+    fetchedAt: string;
+}
+
+export class GetBalancesResponseDto {
+    @ApiProperty({ type: [BalanceDto] })
+    data: BalanceDto[];
+
+    @ApiProperty({ type: BalancesMetaDto })
+    meta: BalancesMetaDto;
+}

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -3,10 +3,11 @@ import { ConfigService } from '@nestjs/config';
 import { Sequelize } from 'sequelize-typescript';
 import { AppUser } from './models/app-user.model';
 import { AuthAuditEvent } from './models/auth-audit-event.model';
+import { BalanceCacheEntry } from './models/balance-cache-entry.model';
 import { WalletLink } from './models/wallet-link.model';
 import { SEQUELIZE } from './database.tokens';
 
-const models = [AppUser, WalletLink, AuthAuditEvent];
+const models = [AppUser, WalletLink, BalanceCacheEntry, AuthAuditEvent];
 
 function databaseUrl(config: ConfigService): string | undefined {
     return config.get<string>('DATABASE_URL') || process.env.DATABASE_URL;

--- a/src/database/models/app-user.model.ts
+++ b/src/database/models/app-user.model.ts
@@ -1,6 +1,8 @@
 import { Column, CreatedAt, DataType, HasMany, Model, Table, UpdatedAt } from 'sequelize-typescript';
 import { WalletLink } from './wallet-link.model';
 
+export type AppUserStatus = 'active' | 'pending_deletion' | 'deleted';
+
 @Table({ tableName: 'app_users', underscored: true })
 export class AppUser extends Model<AppUser> {
     @Column({
@@ -20,7 +22,16 @@ export class AppUser extends Model<AppUser> {
     declare authMethod?: string | null;
 
     @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'active' })
-    declare status: 'active' | 'disabled';
+    declare status: AppUserStatus;
+
+    @Column({ type: DataType.DATE, allowNull: true })
+    declare deletedAt?: Date | null;
+
+    @Column({ type: DataType.DATE, allowNull: true })
+    declare deletionRequestedAt?: Date | null;
+
+    @Column({ type: DataType.DATE, allowNull: true })
+    declare deletionAvailableAt?: Date | null;
 
     @CreatedAt
     declare createdAt: Date;

--- a/src/database/models/balance-cache-entry.model.ts
+++ b/src/database/models/balance-cache-entry.model.ts
@@ -1,0 +1,72 @@
+import { BelongsTo, Column, CreatedAt, DataType, ForeignKey, Model, Table, UpdatedAt } from 'sequelize-typescript';
+import { AppUser } from './app-user.model';
+import { WalletLink } from './wallet-link.model';
+
+@Table({
+    tableName: 'balance_cache_entries',
+    underscored: true,
+    indexes: [
+        { fields: ['user_id'] },
+        { fields: ['wallet_id'] },
+        { fields: ['expires_at'] },
+        { fields: ['user_id', 'wallet_id', 'asset_id'], unique: true },
+    ],
+})
+export class BalanceCacheEntry extends Model<BalanceCacheEntry> {
+    @Column({
+        type: DataType.UUID,
+        defaultValue: DataType.UUIDV4,
+        primaryKey: true,
+    })
+    declare id: string;
+
+    @ForeignKey(() => AppUser)
+    @Column({ type: DataType.UUID, allowNull: false })
+    declare userId: string;
+
+    @ForeignKey(() => WalletLink)
+    @Column({ type: DataType.UUID, allowNull: false })
+    declare walletId: string;
+
+    @Column({ type: DataType.STRING, allowNull: false })
+    declare walletAddress: string;
+
+    @Column({ type: DataType.STRING, allowNull: false })
+    declare chainType: string;
+
+    @Column({ type: DataType.STRING, allowNull: false })
+    declare assetId: string;
+
+    @Column({ type: DataType.STRING, allowNull: false })
+    declare symbol: string;
+
+    @Column({ type: DataType.INTEGER, allowNull: false })
+    declare decimals: number;
+
+    @Column({ type: DataType.STRING, allowNull: false, defaultValue: '0' })
+    declare balanceRaw: string;
+
+    @Column({ type: DataType.STRING, allowNull: true })
+    declare balanceDecimal?: string | null;
+
+    @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'postgres_cache' })
+    declare source: string;
+
+    @Column({ type: DataType.DATE, allowNull: false })
+    declare fetchedAt: Date;
+
+    @Column({ type: DataType.DATE, allowNull: false })
+    declare expiresAt: Date;
+
+    @CreatedAt
+    declare createdAt: Date;
+
+    @UpdatedAt
+    declare updatedAt: Date;
+
+    @BelongsTo(() => AppUser)
+    declare user?: AppUser;
+
+    @BelongsTo(() => WalletLink)
+    declare wallet?: WalletLink;
+}

--- a/src/database/models/wallet-link.model.ts
+++ b/src/database/models/wallet-link.model.ts
@@ -1,6 +1,8 @@
 import { BelongsTo, Column, CreatedAt, DataType, ForeignKey, Model, Table, UpdatedAt } from 'sequelize-typescript';
 import { AppUser } from './app-user.model';
 
+export type WalletLinkStatus = 'active' | 'deleted';
+
 @Table({ tableName: 'wallet_links', underscored: true })
 export class WalletLink extends Model<WalletLink> {
     @Column({
@@ -26,8 +28,17 @@ export class WalletLink extends Model<WalletLink> {
     @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'embedded' })
     declare walletType: string;
 
+    @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'privy' })
+    declare source: string;
+
+    @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'active' })
+    declare status: WalletLinkStatus;
+
     @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
     declare isPrimary: boolean;
+
+    @Column({ type: DataType.DATE, allowNull: true })
+    declare deletedAt?: Date | null;
 
     @CreatedAt
     declare createdAt: Date;


### PR DESCRIPTION
## Summary
- Release backend Privy onboarding support: public runtime auth config, Privy access-token verification, account session creation, and authenticated `/me`.
- Add account lifecycle handling with 30-day soft-delete restore/finalization behavior.
- Add wallet binding APIs for active wallet listing, binding, primary-wallet selection, and soft deletion.
- Add authenticated cached balances API backed by Postgres cache rows.

## Scope
- Backend owns Privy token verification, account/wallet persistence, wallet ownership checks, supported asset validation, and balance cache reads.
- Secrets remain backend-only. Browser clients receive only public auth config and authenticated API responses.
- Balance refresh/RPC provider adapters, rate limits, and metrics remain follow-up hardening work.

## Included PRs
- #205 `feat(auth): expose public onboarding config`
- #207 `feat(auth): add account soft delete lifecycle`
- #208 `feat(auth): add wallet binding apis`
- #209 `feat(auth): add balance cache api`
