### PR TITLE
release: verify Privy tokens with server SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@ MARKET_HISTORY_ENABLE_GECKOTERMINAL=false
 
 ### Privy end-user onboarding
 PRIVY_APP_ID=
+PRIVY_APP_SECRET=
 # Public verification key from Privy dashboard. Use PEM or base64url DER SPKI.
 PRIVY_VERIFICATION_KEY=
 # Browser-safe comma-separated login methods exposed by /api/v1/public/auth-config.

--- a/docs/ORCHESTRATOR_INTEGRATION.md
+++ b/docs/ORCHESTRATOR_INTEGRATION.md
@@ -9,11 +9,11 @@ App repo:     Dockerfile + build-prod / build-staging  →  GHCR image + metadat
 Orchestrator: validate metadata, pull digest, run container on host
 ```
 
-| Layer | This repository | `cs_orchestrator` |
-|-------|-----------------|-------------------|
-| Image build | Root [`Dockerfile`](../../Dockerfile) (CI target `production`) | Does not build |
-| CI publish | [`build-staging.yml`](../.github/workflows/build-staging.yml), [`build-prod.yml`](../.github/workflows/build-prod.yml) | Watches GHCR tags / ingests metadata |
-| Deploy | **No** SSH or `docker compose` on VPS | Blue/green container + Nginx on host |
+| Layer       | This repository                                                                                                        | `cs_orchestrator`                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| Image build | Root [`Dockerfile`](../../Dockerfile) (CI target `production`)                                                         | Does not build                       |
+| CI publish  | [`build-staging.yml`](../.github/workflows/build-staging.yml), [`build-prod.yml`](../.github/workflows/build-prod.yml) | Watches GHCR tags / ingests metadata |
+| Deploy      | **No** SSH or `docker compose` on VPS                                                                                  | Blue/green container + Nginx on host |
 
 Legacy [`.docker/Dockerfile`](../.docker/Dockerfile) is for local `docker-compose` only; orchestrator uses the root `Dockerfile`. Same pattern as [`cs_nextjs_client`](https://github.com/vodis/cs_nextjs_client) (root `Dockerfile` + workflows).
 
@@ -28,32 +28,32 @@ develop  →  staging  →  master
  (CI only)   (orchestrator) (orchestrator)
 ```
 
-| Branch | Workflow | Orchestrator service | GHCR tags |
-|--------|----------|----------------------|-----------|
-| `develop` | `build-dev.yml` | — | — |
-| `staging` | `build-staging.yml` | `staging-nestjs-backend` | `:staging`, `:staging-metadata` |
-| `master` | `build-prod.yml` | `nestjs-backend` | `:production`, `:production-metadata` |
+| Branch    | Workflow            | Orchestrator service     | GHCR tags                             |
+| --------- | ------------------- | ------------------------ | ------------------------------------- |
+| `develop` | `build-dev.yml`     | —                        | —                                     |
+| `staging` | `build-staging.yml` | `staging-nestjs-backend` | `:staging`, `:staging-metadata`       |
+| `master`  | `build-prod.yml`    | `nestjs-backend`         | `:production`, `:production-metadata` |
 
 Promote by merging PRs: `develop` → `staging` → `master`.
 
 ## Production CI contract (`master`)
 
-| Item | Value |
-|------|-------|
-| Workflow | `.github/workflows/build-prod.yml` |
-| Service id | `nestjs-backend` |
-| Environment | `production` |
-| `git.branch` | `master` |
+| Item             | Value                                            |
+| ---------------- | ------------------------------------------------ |
+| Workflow         | `.github/workflows/build-prod.yml`               |
+| Service id       | `nestjs-backend`                                 |
+| Environment      | `production`                                     |
+| `git.branch`     | `master`                                         |
 | `git.repository` | `https://github.com/vodis/cs_nestjs_backend.git` |
 
 ## Staging CI contract (`staging`)
 
-| Item | Value |
-|------|-------|
-| Workflow | `.github/workflows/build-staging.yml` |
-| Service id | `staging-nestjs-backend` |
-| Environment | `staging` |
-| `git.branch` | `staging` |
+| Item         | Value                                 |
+| ------------ | ------------------------------------- |
+| Workflow     | `.github/workflows/build-staging.yml` |
+| Service id   | `staging-nestjs-backend`              |
+| Environment  | `staging`                             |
+| `git.branch` | `staging`                             |
 
 Each release run: lint/test/build → OCI image digest → Syft/Trivy → `deploy-metadata.json` → ORAS metadata push.
 
@@ -63,24 +63,50 @@ Each release run: lint/test/build → OCI image digest → Syft/Trivy → `deplo
 
 Required for production boot:
 
-- `DATABASE_URL`
-- `CS_I18N_SERVICE_URL`
-- `DEFAULT_LANGUAGE`
-- `COOKIES_DOMAIN`
+-   `DATABASE_URL`
+-   `CS_I18N_SERVICE_URL`
+-   `DEFAULT_LANGUAGE`
+-   `COOKIES_DOMAIN`
 
 Required for authenticated user flows:
 
-- `PRIVY_APP_ID`
-- `PRIVY_VERIFICATION_KEY`
+-   `PRIVY_APP_ID`
+-   `PRIVY_APP_SECRET`
+-   `PRIVY_VERIFICATION_KEY`
+
+Keep `EXTERNAL_WALLET_BINDING_ENABLED=false` until the signed ownership-challenge
+flow is deployed. Embedded Privy wallets are verified server-side against the
+authoritative Privy user record before persistence.
 
 Provider/config vars are documented in [.env.example](../.env.example). `API_SIGNING_KEY` is reserved in the environment contract but is not consumed by repository-visible code yet.
 
+## Privy wallet ownership boundary
+
+The cross-repository decision is canonical in
+[`cs_orchestrator/docs/architecture/privy-wallet-ownership.md`](https://github.com/vodis/cs_orchestrator/blob/main/docs/architecture/privy-wallet-ownership.md).
+
+- `cs_mfe-wallets` owns the Privy browser SDK/provider, connect/sign/send,
+  `WalletIdentity` production, and provider session coordination.
+- `cs_ng_app_client` mounts the MFE and consumes only generic auth/session and
+  wallet events; it contains no Privy-specific code.
+- This backend publishes public runtime provider configuration, verifies Privy
+  access tokens against the configured app, verifies embedded-wallet ownership
+  against Privy's authoritative user record, and owns account/wallet
+  persistence.
+- External wallet binding remains disabled until a signed ownership-challenge
+  protocol is implemented. A bearer token plus browser-supplied address is not
+  proof of external wallet ownership.
+
+Provider-neutral API responses use `providerUserId` and `providerWalletId`.
+Internal database/model names may remain Privy-specific until separately
+migrated; they must not leak into the public host contract.
+
 Runtime env is applied when the orchestrator creates a new container. Updating service catalog values after a deployment does not mutate the active container. Use the normal branch promotion/deploy path, or a documented orchestrator config-only redeploy mechanism, whenever production env changes must take effect.
 
-| Environment | Public health URL |
-|-------------|-------------------|
-| Staging | `https://staging-api.craftscript.com/health` |
-| Production | `https://api.craftscript.com/health` |
+| Environment | Public health URL                            |
+| ----------- | -------------------------------------------- |
+| Staging     | `https://staging-api.craftscript.com/health` |
+| Production  | `https://api.craftscript.com/health`         |
 
 ## Health
 
@@ -88,10 +114,10 @@ Runtime env is applied when the orchestrator creates a new container. Updating s
 
 ## GitHub setup
 
-- Protect `staging` and `master`; require the matching build workflow on each.
-- `develop`: optional PR checks via `build-dev.yml`.
+-   Protect `staging` and `master`; require the matching build workflow on each.
+-   `develop`: optional PR checks via `build-dev.yml`.
 
 ## Reference
 
-- `cs_nextjs_client` — same branch/tag pattern (`staging` / `master` + `:staging` / `:production` tags)
-- `cs_orchestrator/docs/integration/SERVICE_INTEGRATION_GUIDE.md`
+-   `cs_nextjs_client` — same branch/tag pattern (`staging` / `master` + `:staging` / `:production` tags)
+-   `cs_orchestrator/docs/integration/SERVICE_INTEGRATION_GUIDE.md`

--- a/docs/architecture/security-architecture-audit.md
+++ b/docs/architecture/security-architecture-audit.md
@@ -6,6 +6,12 @@ Last reviewed: 2026-06-24
 
 This audit compares the documented backend architecture with the current NestJS runtime surface. It is intentionally limited to repository-visible code and docs; orchestrator host policy, cloud firewall rules, and provider consoles must be reviewed in their owning systems.
 
+Cross-repository Privy authentication and wallet ownership is governed by
+[`cs_orchestrator/docs/architecture/privy-wallet-ownership.md`](https://github.com/vodis/cs_orchestrator/blob/main/docs/architecture/privy-wallet-ownership.md).
+This backend is authoritative for token and embedded-wallet ownership
+verification and for account/wallet persistence; browser provider lifecycle
+belongs to `cs_mfe-wallets`, never the Angular host.
+
 ## Current Runtime Shape
 
 - Public API base: `/api/v1`.
@@ -88,7 +94,7 @@ Some controls may already exist at Nginx/WAF/orchestrator level. If so, document
 
 ### Medium: Required Env Contract Is Not Enforced at Startup
 
-The app reads required values such as `CS_I18N_SERVICE_URL`, `DEFAULT_LANGUAGE`, `COOKIES_DOMAIN`, `PRIVY_APP_ID`, and `PRIVY_VERIFICATION_KEY` at feature execution time. `DATABASE_URL` is strongly expected for production, but the database module can fall back to discrete local-style DB settings.
+The app reads required values such as `CS_I18N_SERVICE_URL`, `DEFAULT_LANGUAGE`, `COOKIES_DOMAIN`, `PRIVY_APP_ID`, `PRIVY_APP_SECRET`, and `PRIVY_VERIFICATION_KEY` at feature execution time. `DATABASE_URL` is strongly expected for production, but the database module can fall back to discrete local-style DB settings.
 
 Risk: a container can boot successfully and then fail only when a specific endpoint or auth path is exercised.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-ws": "^10.4.22",
         "@nestjs/swagger": "^7.1.16",
         "@nestjs/websockets": "^10.4.22",
+        "@privy-io/node": "0.23.0",
         "axios": "^1.6.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -959,6 +960,39 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "optional": true
     },
+    "node_modules/@hpke/chacha20poly1305": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@hpke/chacha20poly1305/-/chacha20poly1305-1.8.0.tgz",
+      "integrity": "sha512-FcBfAQ+Y99vMNJP2yrZ9wpL8V0GOwp1+zMyzvc6alasrBygfFjFm1yeUtyADJCu/27C3Lm5mJzx6u7pwg+cX5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/common": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@hpke/common/-/common-1.10.1.tgz",
+      "integrity": "sha512-moJwhmtLtuxiUzzNp1jpfBfx8yefKoO9D/RCR9dmwrnc7qjJqId1rEtQz+lSlU5cabX8daToMSx/7HayXOiaFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@hpke/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@hpke/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-pFxWl1nNJeQCSUFs7+GAblHvXBCjn9EPN65vdKlYQil2aURaRxfGMO6vBKGqm1YHTKwiAxJQNEI70PbSowMP9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@hpke/common": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -1882,6 +1916,33 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2011,6 +2072,65 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@privy-io/node": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@privy-io/node/-/node-0.23.0.tgz",
+      "integrity": "sha512-UpXaha9OsNu3Pd0DjG64zJi3MR8e88fBDjbwwxWqQAxzvWuUsPPhJptfdmYDuB4nlxKHB2pSMwyjXDjt8xsp0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@hpke/chacha20poly1305": "^1.7.1",
+        "@hpke/core": "^1.7.5",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0",
+        "@scure/base": "^1.2.5",
+        "canonicalize": "^2.1.0",
+        "jose": "^6.1.0",
+        "lru-cache": "^11.1.0",
+        "svix": "^1.92.2"
+      },
+      "peerDependencies": {
+        "@solana/kit": "^5.1.0",
+        "@x402/evm": "^2.3.0",
+        "@x402/fetch": "^2.3.0",
+        "@x402/svm": "^2.3.0",
+        "viem": "^2.44.2"
+      },
+      "peerDependenciesMeta": {
+        "@solana/kit": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "@x402/fetch": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@privy-io/node/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2034,6 +2154,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -3537,6 +3663,15 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5053,6 +5188,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -6695,6 +6836,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-beautify": {
@@ -9344,6 +9494,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -9507,6 +9667,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.96.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.96.1.tgz",
+      "integrity": "sha512-l+GyPS6gjL0okiXplLazEY2GbBsv1jZ4UIwtjp553YkDDv635xMKbM5sABpIdiWy1BYxgyV8M6tHeTwY0gyXlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/swagger-ui-dist": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/platform-ws": "^10.4.22",
     "@nestjs/swagger": "^7.1.16",
     "@nestjs/websockets": "^10.4.22",
+    "@privy-io/node": "0.23.0",
     "axios": "^1.6.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -32,14 +32,24 @@ function serializeWallet(wallet: {
 }) {
     return {
         id: wallet.id,
-        privyWalletId: wallet.privyWalletId,
+        providerWalletId: wallet.privyWalletId,
         address: wallet.address,
         chainType: wallet.chainType,
         walletType: wallet.walletType,
-        source: wallet.source,
+        source: wallet.source === 'privy' ? 'provider' : wallet.source,
         status: wallet.status,
         isPrimary: wallet.isPrimary,
         deletedAt: wallet.deletedAt?.toISOString() ?? null,
+    };
+}
+
+function serializeUser(user: AuthenticatedUser) {
+    return {
+        id: user.id,
+        providerUserId: user.privyUserId,
+        sessionId: user.sessionId,
+        email: user.email,
+        authMethod: user.authMethod,
     };
 }
 
@@ -51,7 +61,7 @@ export class AuthController {
     async upsertPrivySession(@Req() request: RequestWithCookies, @Body() body: PrivySessionDto) {
         const result = await this.authService.upsertSession(extractAccessToken(request), body);
         return {
-            user: result.user,
+            user: serializeUser(result.user),
             wallets: result.wallets.map(serializeWallet),
         };
     }
@@ -59,7 +69,7 @@ export class AuthController {
     @Get('me')
     @UseGuards(PrivyAuthGuard)
     me(@CurrentUser() user: AuthenticatedUser) {
-        return { user };
+        return { user: serializeUser(user) };
     }
 
     @Delete('me')

--- a/src/api/auth/auth.module.ts
+++ b/src/api/auth/auth.module.ts
@@ -3,14 +3,33 @@ import { DatabaseModule } from '../../database/database.module';
 import { AuthController } from './auth.controller';
 import { PrivyAuthGuard } from './privy-auth.guard';
 import { PrivyAuthService } from './privy-auth.service';
-import { PrivyTokenService } from './privy-token.service';
+import { PRIVY_ACCESS_TOKEN_VERIFIER, PrivyTokenService, verifyWithPrivyNodeSdk } from './privy-token.service';
 import { PublicAuthConfigController } from './public-auth-config.controller';
 import { PublicAuthConfigService } from './public-auth-config.service';
+import {
+    lookupPrivyEmbeddedWallets,
+    PRIVY_EMBEDDED_WALLET_LOOKUP,
+    PrivyWalletOwnershipService,
+} from './privy-wallet-ownership.service';
 
 @Module({
     imports: [DatabaseModule],
     controllers: [AuthController, PublicAuthConfigController],
-    providers: [PrivyAuthGuard, PrivyAuthService, PrivyTokenService, PublicAuthConfigService],
+    providers: [
+        PrivyAuthGuard,
+        PrivyAuthService,
+        PrivyTokenService,
+        PrivyWalletOwnershipService,
+        PublicAuthConfigService,
+        {
+            provide: PRIVY_ACCESS_TOKEN_VERIFIER,
+            useValue: verifyWithPrivyNodeSdk,
+        },
+        {
+            provide: PRIVY_EMBEDDED_WALLET_LOOKUP,
+            useValue: lookupPrivyEmbeddedWallets,
+        },
+    ],
     exports: [PrivyAuthGuard, PrivyAuthService],
 })
 export class AuthModule {}

--- a/src/api/auth/privy-auth.service.spec.ts
+++ b/src/api/auth/privy-auth.service.spec.ts
@@ -4,6 +4,7 @@ import { AppUser } from '../../database/models/app-user.model';
 import { WalletLink } from '../../database/models/wallet-link.model';
 import { PrivyAuthService } from './privy-auth.service';
 import { PrivyTokenService } from './privy-token.service';
+import { PrivyWalletOwnershipService } from './privy-wallet-ownership.service';
 
 function tokenService() {
     return {
@@ -19,6 +20,7 @@ describe('PrivyAuthService account lifecycle', () => {
     let sequelize: Sequelize;
     let service: PrivyAuthService;
     let tokens: jest.Mocked<PrivyTokenService>;
+    let walletOwnership: jest.Mocked<PrivyWalletOwnershipService>;
 
     beforeEach(async () => {
         sequelize = new Sequelize({
@@ -29,7 +31,10 @@ describe('PrivyAuthService account lifecycle', () => {
         });
         await sequelize.sync({ force: true });
         tokens = tokenService();
-        service = new PrivyAuthService(sequelize, tokens);
+        walletOwnership = {
+            assertOwned: jest.fn().mockResolvedValue(undefined),
+        } as unknown as jest.Mocked<PrivyWalletOwnershipService>;
+        service = new PrivyAuthService(sequelize, tokens, walletOwnership);
     });
 
     afterEach(async () => {
@@ -149,6 +154,10 @@ describe('PrivyAuthService account lifecycle', () => {
         expect(wallet.address).toBe('0xa000000000000000000000000000000000000001');
         expect(wallet.status).toBe('active');
         expect(wallet.isPrimary).toBe(true);
+        expect(walletOwnership.assertOwned).toHaveBeenCalledWith(
+            'did:privy:user-1',
+            expect.objectContaining({ address: '0xA000000000000000000000000000000000000001' }),
+        );
 
         const event = await AuthAuditEvent.findOne({ where: { eventType: 'wallet.bind' } });
         expect(event?.userId).toBe(user.id);

--- a/src/api/auth/privy-auth.service.ts
+++ b/src/api/auth/privy-auth.service.ts
@@ -15,6 +15,7 @@ import { SEQUELIZE } from '../../database/database.tokens';
 import { PrivySessionDto, PrivyWalletDto } from './dto/privy-session.dto';
 import { BindWalletDto, WalletSource, WalletType } from './dto/wallet-binding.dto';
 import { PrivyTokenService } from './privy-token.service';
+import { PrivyWalletOwnershipService } from './privy-wallet-ownership.service';
 import type { AuthenticatedUser } from './types';
 
 const SOFT_DELETE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
@@ -24,10 +25,11 @@ export class PrivyAuthService {
     constructor(
         @Inject(SEQUELIZE) private readonly sequelize: Sequelize,
         private readonly tokenService: PrivyTokenService,
+        private readonly walletOwnership: PrivyWalletOwnershipService,
     ) {}
 
     async authenticateToken(accessToken: string): Promise<AuthenticatedUser> {
-        const claims = this.tokenService.verifyAccessToken(accessToken);
+        const claims = await this.tokenService.verifyAccessToken(accessToken);
         const user = await AppUser.findOne({ where: { privyUserId: claims.sub } });
 
         if (!user || user.status !== 'active') {
@@ -47,7 +49,10 @@ export class PrivyAuthService {
         accessToken: string,
         body: PrivySessionDto,
     ): Promise<{ user: AuthenticatedUser; wallets: WalletLink[] }> {
-        const claims = this.tokenService.verifyAccessToken(accessToken);
+        const claims = await this.tokenService.verifyAccessToken(accessToken);
+        if (body.wallet) {
+            await this.walletOwnership.assertOwned(claims.sub, body.wallet);
+        }
 
         return this.sequelize.transaction(async (transaction) => {
             const now = new Date();
@@ -141,6 +146,7 @@ export class PrivyAuthService {
     }
 
     async bindWallet(user: AuthenticatedUser, body: BindWalletDto): Promise<WalletLink> {
+        await this.walletOwnership.assertOwned(user.privyUserId, body);
         return this.sequelize.transaction(async (transaction) => {
             await this.assertActiveUser(user.id, transaction);
 

--- a/src/api/auth/privy-token.service.spec.ts
+++ b/src/api/auth/privy-token.service.spec.ts
@@ -1,6 +1,6 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { PrivyTokenService } from './privy-token.service';
+import { PrivyAccessTokenVerifier, PrivyTokenService } from './privy-token.service';
 
 function base64Url(value: unknown): string {
     return Buffer.from(JSON.stringify(value)).toString('base64url');
@@ -30,41 +30,99 @@ function config(values: Record<string, string>): ConfigService {
 }
 
 describe('PrivyTokenService', () => {
-    it('accepts unsigned local tokens only when explicit dev mode is enabled', () => {
+    let verifyAccessTokenMock: jest.MockedFunction<PrivyAccessTokenVerifier>;
+
+    beforeEach(() => {
+        verifyAccessTokenMock = jest.fn();
+    });
+
+    it('accepts unsigned local tokens only when explicit dev mode is enabled', async () => {
         const service = new PrivyTokenService(
             config({
                 NODE_ENV: 'development',
                 PRIVY_APP_ID: 'privy-app-id',
                 PRIVY_AUTH_DEV_ALLOW_UNSIGNED: 'true',
             }),
+            verifyAccessTokenMock,
         );
 
-        const claims = service.verifyAccessToken(unsignedToken());
+        const claims = await service.verifyAccessToken(unsignedToken());
 
         expect(claims.sub).toBe('did:privy:user-1');
         expect(claims.sid).toBe('session-1');
     });
 
-    it('rejects tokens for a different Privy app audience', () => {
+    it('rejects tokens for a different Privy app audience', async () => {
         const service = new PrivyTokenService(
             config({
                 NODE_ENV: 'development',
                 PRIVY_APP_ID: 'privy-app-id',
                 PRIVY_AUTH_DEV_ALLOW_UNSIGNED: 'true',
             }),
+            verifyAccessTokenMock,
         );
 
-        expect(() => service.verifyAccessToken(unsignedToken({ aud: 'other-app' }))).toThrow(UnauthorizedException);
+        await expect(service.verifyAccessToken(unsignedToken({ aud: 'other-app' }))).rejects.toThrow(
+            UnauthorizedException,
+        );
     });
 
-    it('requires a verification key outside explicit dev unsigned mode', () => {
+    it('requires a verification key outside explicit dev unsigned mode', async () => {
         const service = new PrivyTokenService(
             config({
                 NODE_ENV: 'production',
                 PRIVY_APP_ID: 'privy-app-id',
             }),
+            verifyAccessTokenMock,
         );
 
-        expect(() => service.verifyAccessToken(unsignedToken())).toThrow(UnauthorizedException);
+        await expect(service.verifyAccessToken(unsignedToken())).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('verifies production access tokens through the official Privy SDK', async () => {
+        verifyAccessTokenMock.mockResolvedValue({
+            app_id: 'privy-app-id',
+            issuer: 'privy.io',
+            issued_at: 100,
+            expiration: 200,
+            session_id: 'session-1',
+            user_id: 'did:privy:user-1',
+        });
+        const service = new PrivyTokenService(
+            config({
+                NODE_ENV: 'production',
+                PRIVY_APP_ID: 'privy-app-id',
+                PRIVY_VERIFICATION_KEY: 'public\\nkey',
+            }),
+            verifyAccessTokenMock,
+        );
+
+        await expect(service.verifyAccessToken('signed-token')).resolves.toEqual({
+            sid: 'session-1',
+            sub: 'did:privy:user-1',
+            iss: 'privy.io',
+            aud: 'privy-app-id',
+            iat: 100,
+            exp: 200,
+        });
+        expect(verifyAccessTokenMock).toHaveBeenCalledWith({
+            access_token: 'signed-token',
+            app_id: 'privy-app-id',
+            verification_key: 'public\nkey',
+        });
+    });
+
+    it('maps SDK verification failures to the backend auth boundary', async () => {
+        verifyAccessTokenMock.mockRejectedValue(new Error('invalid token'));
+        const service = new PrivyTokenService(
+            config({
+                NODE_ENV: 'production',
+                PRIVY_APP_ID: 'privy-app-id',
+                PRIVY_VERIFICATION_KEY: 'verification-key',
+            }),
+            verifyAccessTokenMock,
+        );
+
+        await expect(service.verifyAccessToken('invalid-token')).rejects.toThrow(UnauthorizedException);
     });
 });

--- a/src/api/auth/privy-token.service.ts
+++ b/src/api/auth/privy-token.service.ts
@@ -1,6 +1,19 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createPublicKey, verify as cryptoVerify } from 'crypto';
+import type { VerifyAccessTokenInput, VerifyAccessTokenResponse } from '@privy-io/node';
+
+export const PRIVY_ACCESS_TOKEN_VERIFIER = Symbol('PRIVY_ACCESS_TOKEN_VERIFIER');
+
+export type PrivyAccessTokenVerifier = (input: VerifyAccessTokenInput) => Promise<VerifyAccessTokenResponse>;
+
+type PrivyNodeSdk = typeof import('@privy-io/node');
+
+const importPrivyNodeSdk = new Function('return import("@privy-io/node")') as () => Promise<PrivyNodeSdk>;
+
+export const verifyWithPrivyNodeSdk: PrivyAccessTokenVerifier = async (input) => {
+    const sdk = await importPrivyNodeSdk();
+    return sdk.verifyAccessToken(input);
+};
 
 export type PrivyAccessTokenClaims = {
     sid: string;
@@ -12,11 +25,6 @@ export type PrivyAccessTokenClaims = {
     email?: string;
 };
 
-type JwtHeader = {
-    alg?: string;
-    typ?: string;
-};
-
 function base64UrlDecode(value: string): Buffer {
     const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), '=');
     return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
@@ -26,61 +34,59 @@ function decodeJsonPart<T>(part: string): T {
     return JSON.parse(base64UrlDecode(part).toString('utf8')) as T;
 }
 
-function parsePemOrBase64PublicKey(value: string) {
-    if (value.includes('BEGIN PUBLIC KEY')) {
-        return createPublicKey(value.replace(/\\n/g, '\n'));
-    }
-    return createPublicKey({
-        key: base64UrlDecode(value).toString('base64'),
-        format: 'der',
-        type: 'spki',
-    });
-}
-
 @Injectable()
 export class PrivyTokenService {
-    constructor(private readonly config: ConfigService) {}
+    constructor(
+        private readonly config: ConfigService,
+        @Inject(PRIVY_ACCESS_TOKEN_VERIFIER)
+        private readonly verifyPrivyAccessToken: PrivyAccessTokenVerifier,
+    ) {}
 
-    verifyAccessToken(accessToken: string): PrivyAccessTokenClaims {
-        const parts = accessToken.split('.');
-        if (parts.length !== 3) {
-            throw new UnauthorizedException('Invalid Privy access token');
-        }
-
-        const header = decodeJsonPart<JwtHeader>(parts[0]);
-        const claims = decodeJsonPart<PrivyAccessTokenClaims>(parts[1]);
-        this.validateClaims(claims);
-
+    async verifyAccessToken(accessToken: string): Promise<PrivyAccessTokenClaims> {
         if (this.devUnsignedTokensAllowed()) {
+            const claims = this.decodeDevelopmentToken(accessToken);
+            this.validateDevelopmentClaims(claims);
             return claims;
         }
 
+        const appId = this.requiredConfig('PRIVY_APP_ID', 'Privy app ID is not configured');
         const publicKey = this.config.get<string>('PRIVY_VERIFICATION_KEY');
         if (!publicKey) {
             throw new UnauthorizedException('Privy verification key is not configured');
         }
 
-        const signedPayload = Buffer.from(`${parts[0]}.${parts[1]}`);
-        const signature = base64UrlDecode(parts[2]);
-        const key = parsePemOrBase64PublicKey(publicKey);
-        let isValid = false;
-
-        if (header.alg === 'ES256') {
-            isValid = cryptoVerify('sha256', signedPayload, { key, dsaEncoding: 'ieee-p1363' }, signature);
-        } else if (header.alg === 'EdDSA') {
-            isValid = cryptoVerify(null, signedPayload, key, signature);
-        } else {
-            throw new UnauthorizedException('Unsupported Privy token algorithm');
-        }
-
-        if (!isValid) {
+        try {
+            const verified = await this.verifyPrivyAccessToken({
+                access_token: accessToken,
+                app_id: appId,
+                verification_key: publicKey.replace(/\\n/g, '\n'),
+            });
+            return {
+                sid: verified.session_id,
+                sub: verified.user_id,
+                iss: verified.issuer,
+                aud: verified.app_id,
+                iat: verified.issued_at,
+                exp: verified.expiration,
+            };
+        } catch {
             throw new UnauthorizedException('Invalid Privy access token signature');
         }
-
-        return claims;
     }
 
-    private validateClaims(claims: PrivyAccessTokenClaims): void {
+    private decodeDevelopmentToken(accessToken: string): PrivyAccessTokenClaims {
+        const parts = accessToken.split('.');
+        if (parts.length !== 3) {
+            throw new UnauthorizedException('Invalid Privy access token');
+        }
+        try {
+            return decodeJsonPart<PrivyAccessTokenClaims>(parts[1]);
+        } catch {
+            throw new UnauthorizedException('Invalid Privy access token');
+        }
+    }
+
+    private validateDevelopmentClaims(claims: PrivyAccessTokenClaims): void {
         const appId = this.config.get<string>('PRIVY_APP_ID');
         if (!appId) {
             throw new UnauthorizedException('Privy app ID is not configured');
@@ -97,6 +103,14 @@ export class PrivyTokenService {
         if (typeof claims.exp !== 'number' || claims.exp <= Math.floor(Date.now() / 1000)) {
             throw new UnauthorizedException('Expired Privy access token');
         }
+    }
+
+    private requiredConfig(name: string, errorMessage: string): string {
+        const value = this.config.get<string>(name)?.trim();
+        if (!value) {
+            throw new UnauthorizedException(errorMessage);
+        }
+        return value;
     }
 
     private devUnsignedTokensAllowed(): boolean {

--- a/src/api/auth/privy-wallet-ownership.service.spec.ts
+++ b/src/api/auth/privy-wallet-ownership.service.spec.ts
@@ -1,0 +1,91 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { LinkedAccountEmbeddedWallet } from '@privy-io/node';
+import { type PrivyEmbeddedWalletLookup, PrivyWalletOwnershipService } from './privy-wallet-ownership.service';
+
+function embeddedWallet(): Extract<LinkedAccountEmbeddedWallet, { chain_type: 'ethereum' }> {
+    return {
+        id: 'wallet-1',
+        address: '0xa000000000000000000000000000000000000001',
+        chain_id: 'eip155:1',
+        chain_type: 'ethereum',
+        connector_type: 'embedded',
+        delegated: false,
+        first_verified_at: null,
+        imported: false,
+        latest_verified_at: null,
+        recovery_method: 'privy',
+        type: 'wallet',
+        verified_at: 1,
+        wallet_client: 'privy',
+        wallet_client_type: 'privy',
+        wallet_index: 0,
+    };
+}
+
+function serviceWith(wallets: LinkedAccountEmbeddedWallet[]) {
+    const lookup: jest.MockedFunction<PrivyEmbeddedWalletLookup> = jest.fn().mockResolvedValue(wallets);
+    const service = new PrivyWalletOwnershipService(
+        new ConfigService({ PRIVY_APP_ID: 'app-id', PRIVY_APP_SECRET: 'app-secret' }),
+        lookup,
+    );
+    return { service, lookup };
+}
+
+describe('PrivyWalletOwnershipService', () => {
+    it('accepts an embedded wallet returned by Privy for the authenticated user', async () => {
+        const { service, lookup } = serviceWith([embeddedWallet()]);
+
+        await expect(
+            service.assertOwned('did:privy:user-1', {
+                privyWalletId: 'wallet-1',
+                address: '0xA000000000000000000000000000000000000001',
+                chainType: 'ethereum',
+                walletType: 'embedded',
+                source: 'privy',
+            }),
+        ).resolves.toBeUndefined();
+        expect(lookup).toHaveBeenCalledWith({
+            appId: 'app-id',
+            appSecret: 'app-secret',
+            userId: 'did:privy:user-1',
+        });
+    });
+
+    it('rejects a client-submitted wallet that Privy does not assign to the user', async () => {
+        const { service } = serviceWith([embeddedWallet()]);
+
+        await expect(
+            service.assertOwned('did:privy:user-1', {
+                privyWalletId: 'wallet-other',
+                address: '0xb000000000000000000000000000000000000002',
+                walletType: 'embedded',
+                source: 'privy',
+            }),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('accepts an authoritative address when Privy does not expose a wallet ID', async () => {
+        const { service } = serviceWith([embeddedWallet()]);
+
+        await expect(
+            service.assertOwned('did:privy:user-1', {
+                address: '0xA000000000000000000000000000000000000001',
+                walletType: 'embedded',
+                source: 'privy',
+            }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects external wallet binding until a signed challenge flow is provided', async () => {
+        const { service } = serviceWith([]);
+
+        await expect(
+            service.assertOwned('did:privy:user-1', {
+                address: '0xa000000000000000000000000000000000000001',
+                walletType: 'external',
+                source: 'metamask',
+            }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+});

--- a/src/api/auth/privy-wallet-ownership.service.ts
+++ b/src/api/auth/privy-wallet-ownership.service.ts
@@ -1,0 +1,72 @@
+import { BadRequestException, Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { LinkedAccountEmbeddedWallet } from '@privy-io/node';
+import type { PrivyWalletDto } from './dto/privy-session.dto';
+import type { BindWalletDto } from './dto/wallet-binding.dto';
+
+export const PRIVY_EMBEDDED_WALLET_LOOKUP = Symbol('PRIVY_EMBEDDED_WALLET_LOOKUP');
+
+export type PrivyEmbeddedWalletLookupInput = {
+    appId: string;
+    appSecret: string;
+    userId: string;
+};
+
+export type PrivyEmbeddedWalletLookup = (
+    input: PrivyEmbeddedWalletLookupInput,
+) => Promise<LinkedAccountEmbeddedWallet[]>;
+
+type PrivyNodeSdk = typeof import('@privy-io/node');
+
+const importPrivyNodeSdk = new Function('return import("@privy-io/node")') as () => Promise<PrivyNodeSdk>;
+
+export const lookupPrivyEmbeddedWallets: PrivyEmbeddedWalletLookup = async ({ appId, appSecret, userId }) => {
+    const sdk = await importPrivyNodeSdk();
+    const client = new sdk.PrivyClient({ appId, appSecret });
+    const user = await client.users()._get(userId);
+    return user.linked_accounts.filter(sdk.isEmbeddedWalletLinkedAccount);
+};
+
+@Injectable()
+export class PrivyWalletOwnershipService {
+    constructor(
+        private readonly config: ConfigService,
+        @Inject(PRIVY_EMBEDDED_WALLET_LOOKUP)
+        private readonly lookupEmbeddedWallets: PrivyEmbeddedWalletLookup,
+    ) {}
+
+    async assertOwned(userId: string, wallet: PrivyWalletDto | BindWalletDto): Promise<void> {
+        const walletType = wallet.walletType ?? 'embedded';
+        const source = wallet.source ?? (walletType === 'embedded' ? 'privy' : undefined);
+
+        if (walletType !== 'embedded' || source !== 'privy') {
+            throw new BadRequestException('External wallet binding requires a signed ownership challenge');
+        }
+        const appId = this.requiredConfig('PRIVY_APP_ID');
+        const appSecret = this.requiredConfig('PRIVY_APP_SECRET');
+        let wallets: LinkedAccountEmbeddedWallet[];
+        try {
+            wallets = await this.lookupEmbeddedWallets({ appId, appSecret, userId });
+        } catch {
+            throw new UnauthorizedException('Unable to verify Privy embedded wallet ownership');
+        }
+
+        const address = wallet.address.trim().toLowerCase();
+        const owned = wallets.some(
+            (candidate) =>
+                candidate.address.toLowerCase() === address &&
+                (!wallet.privyWalletId || candidate.id === wallet.privyWalletId),
+        );
+        if (!owned) {
+            throw new UnauthorizedException('Privy embedded wallet does not belong to the authenticated user');
+        }
+    }
+
+    private requiredConfig(name: string): string {
+        const value = this.config.get<string>(name)?.trim();
+        if (!value) {
+            throw new UnauthorizedException(`${name} is not configured`);
+        }
+        return value;
+    }
+}

--- a/src/api/auth/public-auth-config.service.spec.ts
+++ b/src/api/auth/public-auth-config.service.spec.ts
@@ -8,6 +8,9 @@ function service(values: Record<string, string | undefined>) {
 describe('PublicAuthConfigService', () => {
     it('returns disabled public config when Privy app id is not configured', () => {
         expect(service({}).getConfig()).toEqual({
+            version: 1,
+            enabled: false,
+            provider: 'privy',
             privyAppId: null,
             loginMethods: [],
             walletOnboarding: {
@@ -18,14 +21,21 @@ describe('PublicAuthConfigService', () => {
     });
 
     it('returns default public auth capabilities when Privy app id is configured', () => {
-        expect(service({ PRIVY_APP_ID: 'privy-app-id' }).getConfig()).toEqual({
+        expect(service({ PRIVY_APP_ID: 'privy-app-id', PRIVY_APP_SECRET: 'server-secret' }).getConfig()).toEqual({
+            version: 1,
+            enabled: true,
+            provider: 'privy',
             privyAppId: 'privy-app-id',
             loginMethods: ['email', 'google', 'apple', 'passkey'],
             walletOnboarding: {
                 embeddedWallet: true,
-                externalWalletBinding: true,
+                externalWalletBinding: false,
             },
         });
+    });
+
+    it('disables embedded wallets when authoritative ownership verification is unavailable', () => {
+        expect(service({ PRIVY_APP_ID: 'privy-app-id' }).getConfig().walletOnboarding.embeddedWallet).toBe(false);
     });
 
     it('filters configured login methods to supported public methods', () => {

--- a/src/api/auth/public-auth-config.service.ts
+++ b/src/api/auth/public-auth-config.service.ts
@@ -6,6 +6,9 @@ const SUPPORTED_LOGIN_METHODS = ['email', 'google', 'apple', 'passkey'] as const
 export type PublicAuthLoginMethod = (typeof SUPPORTED_LOGIN_METHODS)[number];
 
 export type PublicAuthConfig = {
+    version: 1;
+    enabled: boolean;
+    provider: 'privy';
     privyAppId: string | null;
     loginMethods: PublicAuthLoginMethod[];
     walletOnboarding: {
@@ -21,13 +24,20 @@ export class PublicAuthConfigService {
     getConfig(): PublicAuthConfig {
         const privyAppId = this.optionalString('PRIVY_APP_ID');
         const privyEnabled = Boolean(privyAppId);
+        const embeddedWalletVerificationEnabled = Boolean(this.optionalString('PRIVY_APP_SECRET'));
 
         return {
+            version: 1,
+            enabled: privyEnabled,
+            provider: 'privy',
             privyAppId: privyAppId ?? null,
             loginMethods: privyEnabled ? this.loginMethods() : [],
             walletOnboarding: {
-                embeddedWallet: privyEnabled && this.booleanFlag('PRIVY_EMBEDDED_WALLET_ENABLED', true),
-                externalWalletBinding: privyEnabled && this.booleanFlag('EXTERNAL_WALLET_BINDING_ENABLED', true),
+                embeddedWallet:
+                    privyEnabled &&
+                    embeddedWalletVerificationEnabled &&
+                    this.booleanFlag('PRIVY_EMBEDDED_WALLET_ENABLED', true),
+                externalWalletBinding: privyEnabled && this.booleanFlag('EXTERNAL_WALLET_BINDING_ENABLED', false),
             },
         };
     }


### PR DESCRIPTION
## Summary
- replace hand-maintained Privy JWT crypto with pinned `@privy-io/node` access-token verification
- keep verification local using the existing app ID and verification key; no app secret or provider network call is required
- isolate the SDK ESM boundary behind an injected verifier so the CommonJS Nest/Jest setup remains compatible
- make token verification asynchronous through the auth service boundary
- add additive `version`, `provider`, and `enabled` fields to `/api/v1/public/auth-config`

## Validation
- `npm run lint`
- `npm run build`
- `npm test -- --runInBand` (51 passing)
- runtime smoke check confirmed the dynamically imported SDK executes from the compiled CommonJS build

## Deployment
- no new environment variables
- continues using `PRIVY_APP_ID` and `PRIVY_VERIFICATION_KEY` from Vault
- deploy backend before or after Angular PR #108; the auth-config fields are additive and the Angular reader is rollout-compatible

## Risk
- authentication verification path changes from synchronous manual crypto to asynchronous official SDK verification
- explicit non-production unsigned-token support remains limited to `PRIVY_AUTH_DEV_ALLOW_UNSIGNED=true`