### PR TITLE
release: verify Privy tokens through JWKS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,7 +48,7 @@ MARKET_HISTORY_ENABLE_GECKOTERMINAL=false
 PRIVY_APP_ID=
 PRIVY_APP_SECRET=
 # Public verification key from Privy dashboard. Use PEM or base64url DER SPKI.
-PRIVY_VERIFICATION_KEY=
+PRIVY_JWKS_URL=
 # Browser-safe comma-separated login methods exposed by /api/v1/public/auth-config.
 PRIVY_LOGIN_METHODS=email,google,apple,passkey
 # Browser-safe onboarding capability flags exposed by /api/v1/public/auth-config.

--- a/docs/ORCHESTRATOR_INTEGRATION.md
+++ b/docs/ORCHESTRATOR_INTEGRATION.md
@@ -72,7 +72,7 @@ Required for authenticated user flows:
 
 -   `PRIVY_APP_ID`
 -   `PRIVY_APP_SECRET`
--   `PRIVY_VERIFICATION_KEY`
+-   `PRIVY_JWKS_URL`
 
 Keep `EXTERNAL_WALLET_BINDING_ENABLED=false` until the signed ownership-challenge
 flow is deployed. Embedded Privy wallets are verified server-side against the

--- a/docs/architecture/security-architecture-audit.md
+++ b/docs/architecture/security-architecture-audit.md
@@ -94,7 +94,7 @@ Some controls may already exist at Nginx/WAF/orchestrator level. If so, document
 
 ### Medium: Required Env Contract Is Not Enforced at Startup
 
-The app reads required values such as `CS_I18N_SERVICE_URL`, `DEFAULT_LANGUAGE`, `COOKIES_DOMAIN`, `PRIVY_APP_ID`, `PRIVY_APP_SECRET`, and `PRIVY_VERIFICATION_KEY` at feature execution time. `DATABASE_URL` is strongly expected for production, but the database module can fall back to discrete local-style DB settings.
+The app reads required values such as `CS_I18N_SERVICE_URL`, `DEFAULT_LANGUAGE`, `COOKIES_DOMAIN`, `PRIVY_APP_ID`, `PRIVY_APP_SECRET`, and `PRIVY_JWKS_URL` at feature execution time. `DATABASE_URL` is strongly expected for production, but the database module can fall back to discrete local-style DB settings.
 
 Risk: a container can boot successfully and then fail only when a specific endpoint or auth path is exercised.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.6",
+        "jose": "^5.10.0",
         "pg": "^8.11.3",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
@@ -2111,6 +2112,15 @@
         "viem": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@privy-io/node/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@privy-io/node/node_modules/lru-cache": {
@@ -6839,9 +6849,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.6",
+    "jose": "^5.10.0",
     "pg": "^8.11.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/src/api/auth/auth.module.ts
+++ b/src/api/auth/auth.module.ts
@@ -3,7 +3,7 @@ import { DatabaseModule } from '../../database/database.module';
 import { AuthController } from './auth.controller';
 import { PrivyAuthGuard } from './privy-auth.guard';
 import { PrivyAuthService } from './privy-auth.service';
-import { PRIVY_ACCESS_TOKEN_VERIFIER, PrivyTokenService, verifyWithPrivyNodeSdk } from './privy-token.service';
+import { PrivyTokenService } from './privy-token.service';
 import { PublicAuthConfigController } from './public-auth-config.controller';
 import { PublicAuthConfigService } from './public-auth-config.service';
 import {
@@ -21,10 +21,6 @@ import {
         PrivyTokenService,
         PrivyWalletOwnershipService,
         PublicAuthConfigService,
-        {
-            provide: PRIVY_ACCESS_TOKEN_VERIFIER,
-            useValue: verifyWithPrivyNodeSdk,
-        },
         {
             provide: PRIVY_EMBEDDED_WALLET_LOOKUP,
             useValue: lookupPrivyEmbeddedWallets,

--- a/src/api/auth/privy-token.service.spec.ts
+++ b/src/api/auth/privy-token.service.spec.ts
@@ -1,6 +1,8 @@
 import { UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { PrivyAccessTokenVerifier, PrivyTokenService } from './privy-token.service';
+import { createServer } from 'http';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { PrivyTokenService } from './privy-token.service';
 
 function base64Url(value: unknown): string {
     return Buffer.from(JSON.stringify(value)).toString('base64url');
@@ -30,10 +32,45 @@ function config(values: Record<string, string>): ConfigService {
 }
 
 describe('PrivyTokenService', () => {
-    let verifyAccessTokenMock: jest.MockedFunction<PrivyAccessTokenVerifier>;
+    it('verifies a signed access token using the configured JWKS endpoint', async () => {
+        const { publicKey, privateKey } = await generateKeyPair('ES256');
+        const publicJwk = await exportJWK(publicKey);
+        const server = createServer((_request, response) => {
+            response.setHeader('Content-Type', 'application/json');
+            response.end(JSON.stringify({ keys: [{ ...publicJwk, alg: 'ES256', kid: 'key-1' }] }));
+        });
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+            server.close();
+            throw new Error('test JWKS server did not bind to a TCP port');
+        }
 
-    beforeEach(() => {
-        verifyAccessTokenMock = jest.fn();
+        try {
+            const now = Math.floor(Date.now() / 1000);
+            const token = await new SignJWT({ sid: 'session-1' })
+                .setProtectedHeader({ alg: 'ES256', kid: 'key-1' })
+                .setSubject('did:privy:user-1')
+                .setIssuer('privy.io')
+                .setAudience('privy-app-id')
+                .setIssuedAt(now)
+                .setExpirationTime(now + 3600)
+                .sign(privateKey);
+            const service = new PrivyTokenService(
+                config({
+                    NODE_ENV: 'test',
+                    PRIVY_APP_ID: 'privy-app-id',
+                    PRIVY_JWKS_URL: `http://127.0.0.1:${address.port}/jwks.json`,
+                }),
+            );
+
+            const claims = await service.verifyAccessToken(token);
+
+            expect(claims.sub).toBe('did:privy:user-1');
+            expect(claims.sid).toBe('session-1');
+        } finally {
+            await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+        }
     });
 
     it('accepts unsigned local tokens only when explicit dev mode is enabled', async () => {
@@ -43,7 +80,6 @@ describe('PrivyTokenService', () => {
                 PRIVY_APP_ID: 'privy-app-id',
                 PRIVY_AUTH_DEV_ALLOW_UNSIGNED: 'true',
             }),
-            verifyAccessTokenMock,
         );
 
         const claims = await service.verifyAccessToken(unsignedToken());
@@ -59,7 +95,6 @@ describe('PrivyTokenService', () => {
                 PRIVY_APP_ID: 'privy-app-id',
                 PRIVY_AUTH_DEV_ALLOW_UNSIGNED: 'true',
             }),
-            verifyAccessTokenMock,
         );
 
         await expect(service.verifyAccessToken(unsignedToken({ aud: 'other-app' }))).rejects.toThrow(
@@ -67,62 +102,26 @@ describe('PrivyTokenService', () => {
         );
     });
 
-    it('requires a verification key outside explicit dev unsigned mode', async () => {
+    it('requires a JWKS URL outside explicit dev unsigned mode', async () => {
         const service = new PrivyTokenService(
             config({
                 NODE_ENV: 'production',
                 PRIVY_APP_ID: 'privy-app-id',
             }),
-            verifyAccessTokenMock,
         );
 
-        await expect(service.verifyAccessToken(unsignedToken())).rejects.toThrow(UnauthorizedException);
+        await expect(service.verifyAccessToken(unsignedToken())).rejects.toThrow('Privy JWKS URL is not configured');
     });
 
-    it('verifies production access tokens through the official Privy SDK', async () => {
-        verifyAccessTokenMock.mockResolvedValue({
-            app_id: 'privy-app-id',
-            issuer: 'privy.io',
-            issued_at: 100,
-            expiration: 200,
-            session_id: 'session-1',
-            user_id: 'did:privy:user-1',
-        });
+    it('requires HTTPS JWKS in production', async () => {
         const service = new PrivyTokenService(
             config({
                 NODE_ENV: 'production',
                 PRIVY_APP_ID: 'privy-app-id',
-                PRIVY_VERIFICATION_KEY: 'public\\nkey',
+                PRIVY_JWKS_URL: 'http://privy.example.test/.well-known/jwks.json',
             }),
-            verifyAccessTokenMock,
         );
 
-        await expect(service.verifyAccessToken('signed-token')).resolves.toEqual({
-            sid: 'session-1',
-            sub: 'did:privy:user-1',
-            iss: 'privy.io',
-            aud: 'privy-app-id',
-            iat: 100,
-            exp: 200,
-        });
-        expect(verifyAccessTokenMock).toHaveBeenCalledWith({
-            access_token: 'signed-token',
-            app_id: 'privy-app-id',
-            verification_key: 'public\nkey',
-        });
-    });
-
-    it('maps SDK verification failures to the backend auth boundary', async () => {
-        verifyAccessTokenMock.mockRejectedValue(new Error('invalid token'));
-        const service = new PrivyTokenService(
-            config({
-                NODE_ENV: 'production',
-                PRIVY_APP_ID: 'privy-app-id',
-                PRIVY_VERIFICATION_KEY: 'verification-key',
-            }),
-            verifyAccessTokenMock,
-        );
-
-        await expect(service.verifyAccessToken('invalid-token')).rejects.toThrow(UnauthorizedException);
+        await expect(service.verifyAccessToken(unsignedToken())).rejects.toThrow('Privy JWKS URL must use HTTPS');
     });
 });

--- a/src/api/auth/privy-token.service.ts
+++ b/src/api/auth/privy-token.service.ts
@@ -1,19 +1,6 @@
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import type { VerifyAccessTokenInput, VerifyAccessTokenResponse } from '@privy-io/node';
-
-export const PRIVY_ACCESS_TOKEN_VERIFIER = Symbol('PRIVY_ACCESS_TOKEN_VERIFIER');
-
-export type PrivyAccessTokenVerifier = (input: VerifyAccessTokenInput) => Promise<VerifyAccessTokenResponse>;
-
-type PrivyNodeSdk = typeof import('@privy-io/node');
-
-const importPrivyNodeSdk = new Function('return import("@privy-io/node")') as () => Promise<PrivyNodeSdk>;
-
-export const verifyWithPrivyNodeSdk: PrivyAccessTokenVerifier = async (input) => {
-    const sdk = await importPrivyNodeSdk();
-    return sdk.verifyAccessToken(input);
-};
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from 'jose';
 
 export type PrivyAccessTokenClaims = {
     sid: string;
@@ -25,72 +12,77 @@ export type PrivyAccessTokenClaims = {
     email?: string;
 };
 
-function base64UrlDecode(value: string): Buffer {
-    const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), '=');
-    return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
-}
-
-function decodeJsonPart<T>(part: string): T {
-    return JSON.parse(base64UrlDecode(part).toString('utf8')) as T;
-}
-
 @Injectable()
 export class PrivyTokenService {
-    constructor(
-        private readonly config: ConfigService,
-        @Inject(PRIVY_ACCESS_TOKEN_VERIFIER)
-        private readonly verifyPrivyAccessToken: PrivyAccessTokenVerifier,
-    ) {}
+    private jwks?: ReturnType<typeof createRemoteJWKSet>;
+
+    constructor(private readonly config: ConfigService) {}
 
     async verifyAccessToken(accessToken: string): Promise<PrivyAccessTokenClaims> {
         if (this.devUnsignedTokensAllowed()) {
-            const claims = this.decodeDevelopmentToken(accessToken);
-            this.validateDevelopmentClaims(claims);
+            const claims = this.decodeToken(accessToken);
+            this.validateClaims(claims);
             return claims;
         }
 
         const appId = this.requiredConfig('PRIVY_APP_ID', 'Privy app ID is not configured');
-        const publicKey = this.config.get<string>('PRIVY_VERIFICATION_KEY');
-        if (!publicKey) {
-            throw new UnauthorizedException('Privy verification key is not configured');
-        }
+        const jwks = this.remoteJwks();
 
         try {
-            const verified = await this.verifyPrivyAccessToken({
-                access_token: accessToken,
-                app_id: appId,
-                verification_key: publicKey.replace(/\\n/g, '\n'),
+            const { payload } = await jwtVerify(accessToken, jwks, {
+                algorithms: ['ES256'],
+                issuer: 'privy.io',
+                audience: appId,
             });
-            return {
-                sid: verified.session_id,
-                sub: verified.user_id,
-                iss: verified.issuer,
-                aud: verified.app_id,
-                iat: verified.issued_at,
-                exp: verified.expiration,
-            };
-        } catch {
-            throw new UnauthorizedException('Invalid Privy access token signature');
+            const claims = payload as unknown as PrivyAccessTokenClaims;
+            this.validateClaims(claims);
+            return claims;
+        } catch (error) {
+            if (error instanceof UnauthorizedException) {
+                throw error;
+            }
+            throw new UnauthorizedException('Invalid Privy access token');
         }
     }
 
-    private decodeDevelopmentToken(accessToken: string): PrivyAccessTokenClaims {
-        const parts = accessToken.split('.');
-        if (parts.length !== 3) {
-            throw new UnauthorizedException('Invalid Privy access token');
-        }
+    private decodeToken(accessToken: string): PrivyAccessTokenClaims {
         try {
-            return decodeJsonPart<PrivyAccessTokenClaims>(parts[1]);
+            return decodeJwt(accessToken) as unknown as PrivyAccessTokenClaims;
         } catch {
             throw new UnauthorizedException('Invalid Privy access token');
         }
     }
 
-    private validateDevelopmentClaims(claims: PrivyAccessTokenClaims): void {
-        const appId = this.config.get<string>('PRIVY_APP_ID');
-        if (!appId) {
-            throw new UnauthorizedException('Privy app ID is not configured');
+    private remoteJwks(): ReturnType<typeof createRemoteJWKSet> {
+        if (this.jwks) {
+            return this.jwks;
         }
+
+        const rawUrl = this.requiredConfig('PRIVY_JWKS_URL', 'Privy JWKS URL is not configured');
+        let url: URL;
+        try {
+            url = new URL(rawUrl);
+        } catch {
+            throw new UnauthorizedException('Privy JWKS URL is invalid');
+        }
+        if (this.config.get<string>('NODE_ENV') === 'production' && url.protocol !== 'https:') {
+            throw new UnauthorizedException('Privy JWKS URL must use HTTPS');
+        }
+
+        this.jwks = createRemoteJWKSet(url);
+        return this.jwks;
+    }
+
+    private requiredConfig(key: string, message: string): string {
+        const value = this.config.get<string>(key)?.trim();
+        if (!value) {
+            throw new UnauthorizedException(message);
+        }
+        return value;
+    }
+
+    private validateClaims(claims: PrivyAccessTokenClaims): void {
+        const appId = this.requiredConfig('PRIVY_APP_ID', 'Privy app ID is not configured');
         if (claims.iss !== 'privy.io') {
             throw new UnauthorizedException('Invalid Privy token issuer');
         }
@@ -103,14 +95,6 @@ export class PrivyTokenService {
         if (typeof claims.exp !== 'number' || claims.exp <= Math.floor(Date.now() / 1000)) {
             throw new UnauthorizedException('Expired Privy access token');
         }
-    }
-
-    private requiredConfig(name: string, errorMessage: string): string {
-        const value = this.config.get<string>(name)?.trim();
-        if (!value) {
-            throw new UnauthorizedException(errorMessage);
-        }
-        return value;
     }
 
     private devUnsignedTokensAllowed(): boolean {

--- a/src/api/auth/public-auth-config.service.spec.ts
+++ b/src/api/auth/public-auth-config.service.spec.ts
@@ -64,7 +64,7 @@ describe('PublicAuthConfigService', () => {
         expect(
             service({
                 PRIVY_APP_ID: 'privy-app-id',
-                PRIVY_VERIFICATION_KEY: 'server-only-key',
+                PRIVY_JWKS_URL: 'https://auth.privy.io/example/jwks.json',
             }).getConfig(),
         ).not.toHaveProperty('privyVerificationKey');
     });


### PR DESCRIPTION
## Summary
- verify Privy ES256 access tokens through the dashboard-provided JWKS endpoint
- validate issuer, audience, expiry, subject, and session claims
- remove the static verification-key dependency and update runtime documentation
- add signed-token JWKS regression coverage

## Validation
- npm test -- --runInBand src/api/auth/privy-token.service.spec.ts
- npm run build

## Rollout
Set PRIVY_JWKS_URL to the exact Privy dashboard JWKS Endpoint in the nestjs-backend Vault secret before deployment. Remove PRIVY_VERIFICATION_KEY after successful health and login verification.