### PR TITLE
release: enabled passkey and block releases with schema drift

### DIFF
--- a/db/migrations/20260711000100-add-passkey-enabled-to-app-users.js
+++ b/db/migrations/20260711000100-add-passkey-enabled-to-app-users.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('app_users', 'passkey_enabled', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('app_users', 'passkey_enabled');
+  },
+};

--- a/db/verify.js
+++ b/db/verify.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REQUIRED_TABLES = ['app_users', 'wallet_links', 'auth_audit_events'];
+
+function expectedMigrations(directory = path.join(__dirname, 'migrations')) {
+  return fs
+    .readdirSync(directory)
+    .filter((name) => name.endsWith('.js'))
+    .sort();
+}
+
+function verifyState(expected, applied, requiredTables, existingTables) {
+  const appliedSet = new Set(applied);
+  const tableSet = new Set(existingTables);
+  return {
+    pendingMigrations: expected.filter((name) => !appliedSet.has(name)),
+    missingTables: requiredTables.filter((name) => !tableSet.has(name)),
+  };
+}
+
+function connectionConfig() {
+  const environment = process.env.NODE_ENV || 'development';
+  const config = require('./config')[environment];
+  if (!config) {
+    throw new Error(`Unknown database environment: ${environment}`);
+  }
+  if (config.url) {
+    return { connectionString: config.url };
+  }
+  return {
+    host: config.host,
+    port: config.port,
+    database: config.database,
+    user: config.username,
+    password: config.password,
+  };
+}
+
+async function inspectDatabase(client) {
+  const metadata = await client.query("SELECT to_regclass('\"SequelizeMeta\"') AS table_name");
+  let applied = [];
+  if (metadata.rows[0].table_name) {
+    const result = await client.query('SELECT name FROM "SequelizeMeta" ORDER BY name');
+    applied = result.rows.map(({ name }) => name);
+  }
+
+  const tables = await client.query(
+    `SELECT table_name
+       FROM information_schema.tables
+      WHERE table_schema = current_schema()
+        AND table_name = ANY($1::text[])`,
+    [REQUIRED_TABLES],
+  );
+
+  return verifyState(
+    expectedMigrations(),
+    applied,
+    REQUIRED_TABLES,
+    tables.rows.map(({ table_name: tableName }) => tableName),
+  );
+}
+
+async function main() {
+  const { Client } = require('pg');
+  const client = new Client(connectionConfig());
+  await client.connect();
+  try {
+    const result = await inspectDatabase(client);
+    if (result.pendingMigrations.length || result.missingTables.length) {
+      if (result.pendingMigrations.length) {
+        console.error(`Pending database migrations: ${result.pendingMigrations.join(', ')}`);
+      }
+      if (result.missingTables.length) {
+        console.error(`Missing required database tables: ${result.missingTables.join(', ')}`);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    console.log('Database migration and schema verification passed.');
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Database verification failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { REQUIRED_TABLES, expectedMigrations, verifyState };

--- a/db/verify.test.js
+++ b/db/verify.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { verifyState } = require('./verify');
+
+test('reports pending migrations and missing required tables', () => {
+  const result = verifyState(
+    ['001-existing.js', '002-pending.js'],
+    ['001-existing.js'],
+    ['app_users', 'wallet_links'],
+    ['app_users'],
+  );
+
+  assert.deepEqual(result, {
+    pendingMigrations: ['002-pending.js'],
+    missingTables: ['wallet_links'],
+  });
+});
+
+test('passes when migrations and required tables are present', () => {
+  const result = verifyState(
+    ['001-existing.js'],
+    ['001-existing.js'],
+    ['app_users'],
+    ['app_users'],
+  );
+
+  assert.deepEqual(result, { pendingMigrations: [], missingTables: [] });
+});

--- a/docs/ORCHESTRATOR_INTEGRATION.md
+++ b/docs/ORCHESTRATOR_INTEGRATION.md
@@ -93,6 +93,10 @@ The cross-repository decision is canonical in
   access tokens against the configured app, verifies embedded-wallet ownership
   against Privy's authoritative user record, and owns account/wallet
   persistence.
+- Passkey enablement is exposed as provider-neutral account state
+  (`POST /api/v1/me/passkey`, `passkeyEnabled`). The current guard is Privy
+  because Privy is the active auth provider, but the backend does not persist
+  Privy passkey credential IDs or linked-account payloads.
 - External wallet binding remains disabled until a signed ownership-challenge
   protocol is implemented. A bearer token plus browser-supplied address is not
   proof of external wallet ownership.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "db:migrate": "sequelize-cli db:migrate --config db/config.js --migrations-path db/migrations",
     "db:migrate:status": "sequelize-cli db:migrate:status --config db/config.js --migrations-path db/migrations",
-    "db:smoke": "node db/smoke.js"
+    "db:smoke": "node db/smoke.js",
+    "db:verify": "node db/verify.js",
+    "db:verify:test": "node --test db/verify.test.js"
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.1",

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -50,6 +50,7 @@ function serializeUser(user: AuthenticatedUser) {
         sessionId: user.sessionId,
         email: user.email,
         authMethod: user.authMethod,
+        passkeyEnabled: user.passkeyEnabled,
     };
 }
 
@@ -79,6 +80,16 @@ export class AuthController {
         return {
             status: 'pending_deletion',
             deletionAvailableAt: result.deletionAvailableAt.toISOString(),
+        };
+    }
+
+    @Post('me/passkey')
+    @UseGuards(PrivyAuthGuard)
+    async enablePasskey(@CurrentUser() user: AuthenticatedUser) {
+        const result = await this.authService.enablePasskey(user);
+        return {
+            user: serializeUser(result.user),
+            wallets: result.wallets.map(serializeWallet),
         };
     }
 

--- a/src/api/auth/privy-auth.service.spec.ts
+++ b/src/api/auth/privy-auth.service.spec.ts
@@ -51,6 +51,7 @@ describe('PrivyAuthService account lifecycle', () => {
             id: user.id,
             privyUserId: user.privyUserId,
             sessionId: 'session-1',
+            passkeyEnabled: false,
         });
 
         await user.reload();
@@ -78,6 +79,7 @@ describe('PrivyAuthService account lifecycle', () => {
 
         await user.reload();
         expect(result.user.id).toBe(user.id);
+        expect(result.user.passkeyEnabled).toBe(false);
         expect(user.status).toBe('active');
         expect(user.deletionRequestedAt).toBeNull();
         expect(user.deletionAvailableAt).toBeNull();
@@ -103,9 +105,47 @@ describe('PrivyAuthService account lifecycle', () => {
         expect(oldUser.privyUserId).toBe(`deleted:${oldUser.id}:did:privy:user-1`);
         expect(result.user.id).not.toBe(oldUser.id);
         expect(result.user.privyUserId).toBe('did:privy:user-1');
+        expect(result.user.passkeyEnabled).toBe(false);
 
         const events = await AuthAuditEvent.findAll({ order: [['createdAt', 'ASC']] });
         expect(events.map((event) => event.eventType)).toEqual(['account.final_purge', 'account.signup']);
+    });
+
+    it('preserves passkey-enabled state when the user signs in again', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+            passkeyEnabled: true,
+        });
+
+        const result = await service.upsertSession('token', { authMethod: 'email' });
+
+        await user.reload();
+        expect(result.user.id).toBe(user.id);
+        expect(result.user.passkeyEnabled).toBe(true);
+        expect(user.passkeyEnabled).toBe(true);
+    });
+
+    it('marks passkey enabled for an active account and records an audit event', async () => {
+        const user = await AppUser.create({
+            privyUserId: 'did:privy:user-1',
+            status: 'active',
+        });
+
+        const result = await service.enablePasskey({
+            id: user.id,
+            privyUserId: user.privyUserId,
+            sessionId: 'session-1',
+            passkeyEnabled: false,
+        });
+
+        await user.reload();
+        expect(result.user.passkeyEnabled).toBe(true);
+        expect(user.passkeyEnabled).toBe(true);
+
+        const event = await AuthAuditEvent.findOne({ where: { eventType: 'account.passkey_enabled' } });
+        expect(event?.userId).toBe(user.id);
+        expect(event?.metadata).toMatchObject({ sessionId: 'session-1' });
     });
 
     it('purges pending-deletion accounts whose retention window has elapsed', async () => {
@@ -142,6 +182,7 @@ describe('PrivyAuthService account lifecycle', () => {
                 id: user.id,
                 privyUserId: user.privyUserId,
                 sessionId: 'session-1',
+                passkeyEnabled: false,
             },
             {
                 address: '0xA000000000000000000000000000000000000001',
@@ -179,6 +220,7 @@ describe('PrivyAuthService account lifecycle', () => {
                     id: user.id,
                     privyUserId: user.privyUserId,
                     sessionId: 'session-1',
+                    passkeyEnabled: false,
                 },
                 {
                     address: '0xA000000000000000000000000000000000000001',
@@ -220,6 +262,7 @@ describe('PrivyAuthService account lifecycle', () => {
                 id: user.id,
                 privyUserId: user.privyUserId,
                 sessionId: 'session-1',
+                passkeyEnabled: false,
             },
             second.id,
         );
@@ -262,6 +305,7 @@ describe('PrivyAuthService account lifecycle', () => {
                 id: user.id,
                 privyUserId: user.privyUserId,
                 sessionId: 'session-1',
+                passkeyEnabled: false,
             },
             first.id,
         );
@@ -301,6 +345,7 @@ describe('PrivyAuthService account lifecycle', () => {
                 id: user.id,
                 privyUserId: user.privyUserId,
                 sessionId: 'session-1',
+                passkeyEnabled: false,
             },
             {
                 address: '0xA000000000000000000000000000000000000001',

--- a/src/api/auth/privy-auth.service.ts
+++ b/src/api/auth/privy-auth.service.ts
@@ -42,6 +42,7 @@ export class PrivyAuthService {
             sessionId: claims.sid,
             email: user.email,
             authMethod: user.authMethod,
+            passkeyEnabled: user.passkeyEnabled,
         };
     }
 
@@ -77,6 +78,7 @@ export class PrivyAuthService {
                     privyUserId: claims.sub,
                     email: body.email || claims.email || null,
                     authMethod: body.authMethod || null,
+                    passkeyEnabled: false,
                     status: 'active',
                 },
                 transaction,
@@ -129,6 +131,50 @@ export class PrivyAuthService {
                     sessionId: claims.sid,
                     email: user.email,
                     authMethod: user.authMethod,
+                    passkeyEnabled: user.passkeyEnabled,
+                },
+                wallets,
+            };
+        });
+    }
+
+    async enablePasskey(user: AuthenticatedUser): Promise<{ user: AuthenticatedUser; wallets: WalletLink[] }> {
+        return this.sequelize.transaction(async (transaction) => {
+            const appUser = await AppUser.findByPk(user.id, { transaction });
+            if (!appUser || appUser.status !== 'active') {
+                throw new UnauthorizedException('Authenticated Privy user is not active');
+            }
+
+            await appUser.update({ passkeyEnabled: true }, { transaction });
+            await AuthAuditEvent.create(
+                {
+                    userId: appUser.id,
+                    privyUserId: appUser.privyUserId,
+                    eventType: 'account.passkey_enabled',
+                    metadata: {
+                        sessionId: user.sessionId,
+                    },
+                },
+                { transaction },
+            );
+
+            const wallets = await WalletLink.findAll({
+                where: { userId: appUser.id, status: 'active' },
+                order: [
+                    ['isPrimary', 'DESC'],
+                    ['createdAt', 'ASC'],
+                ],
+                transaction,
+            });
+
+            return {
+                user: {
+                    id: appUser.id,
+                    privyUserId: appUser.privyUserId,
+                    sessionId: user.sessionId,
+                    email: appUser.email,
+                    authMethod: appUser.authMethod,
+                    passkeyEnabled: appUser.passkeyEnabled,
                 },
                 wallets,
             };

--- a/src/api/auth/types.ts
+++ b/src/api/auth/types.ts
@@ -4,4 +4,5 @@ export type AuthenticatedUser = {
     sessionId: string;
     email?: string | null;
     authMethod?: string | null;
+    passkeyEnabled: boolean;
 };

--- a/src/api/balances/balances.service.spec.ts
+++ b/src/api/balances/balances.service.spec.ts
@@ -71,7 +71,7 @@ describe('BalancesService', () => {
         });
 
         const result = await service.getBalances(
-            { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+            { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1', passkeyEnabled: false },
             {},
         );
 
@@ -121,7 +121,7 @@ describe('BalancesService', () => {
         });
 
         const result = await service.getBalances(
-            { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+            { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1', passkeyEnabled: false },
             {},
         );
 
@@ -144,7 +144,7 @@ describe('BalancesService', () => {
 
         await expect(
             service.getBalances(
-                { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+                { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1', passkeyEnabled: false },
                 { walletId: otherWallet.id },
             ),
         ).rejects.toBeInstanceOf(NotFoundException);
@@ -155,7 +155,7 @@ describe('BalancesService', () => {
 
         await expect(
             service.getBalances(
-                { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1' },
+                { id: user.id, privyUserId: user.privyUserId, sessionId: 'session-1', passkeyEnabled: false },
                 { assetId: 'unsupported' },
             ),
         ).rejects.toBeInstanceOf(BadRequestException);

--- a/src/database/models/app-user.model.ts
+++ b/src/database/models/app-user.model.ts
@@ -21,6 +21,9 @@ export class AppUser extends Model<AppUser> {
     @Column({ type: DataType.STRING, allowNull: true })
     declare authMethod?: string | null;
 
+    @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: false })
+    declare passkeyEnabled: boolean;
+
     @Column({ type: DataType.STRING, allowNull: false, defaultValue: 'active' })
     declare status: AppUserStatus;
 


### PR DESCRIPTION
## Summary
- add passkeyEnabled account state and migration
- add guarded POST /api/v1/me/passkey marker endpoint
- document provider-neutral backend boundary

## Verification
- npm test -- privy-auth.service.spec.ts balances.service.spec.ts --runInBand
- npm run build