### PR TITLE
release: enable passkey login in default public auth config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,9 +50,9 @@ PRIVY_APP_SECRET=
 # Public verification key from Privy dashboard. Use PEM or base64url DER SPKI.
 PRIVY_JWKS_URL=
 # Browser-safe comma-separated login methods exposed by /api/v1/public/auth-config.
-# Passkey login is intentionally opt-in; add ",passkey" only after the
-# browser/provider RP configuration is verified for the deployed host.
-PRIVY_LOGIN_METHODS=email,google,apple
+# Default backend config includes passkey when PRIVY_LOGIN_METHODS is unset.
+# Remove passkey here only if WebAuthn relying-party config is not ready.
+PRIVY_LOGIN_METHODS=email,google,apple,passkey
 # Browser-safe passkey capability flags exposed by /api/v1/public/auth-config.
 # Login is also gated by PRIVY_LOGIN_METHODS; this flag is an emergency kill switch.
 PRIVY_PASSKEY_LOGIN_ENABLED=true

--- a/docs/ORCHESTRATOR_INTEGRATION.md
+++ b/docs/ORCHESTRATOR_INTEGRATION.md
@@ -82,17 +82,16 @@ Provider/config vars are documented in [.env.example](../.env.example). `API_SIG
 
 Passkey enrollment and passkey login are separate capabilities. Users first
 authenticate with an existing CCO method such as email, Google, or Apple, then
-enable a passkey on the authenticated account. Keep
-`PRIVY_LOGIN_METHODS=email,google,apple` unless passkey WebAuthn relying-party
-configuration has been verified for the deployed host and passkey login is
-ready to be offered for already-enrolled accounts.
+enable a passkey on the authenticated account. The backend default public auth
+config now includes passkey login when Privy is enabled.
 
-Enabling passkey login requires `passkey` in `PRIVY_LOGIN_METHODS`.
-`PRIVY_PASSKEY_LOGIN_ENABLED` is an emergency kill switch for passkey login
-when `PRIVY_LOGIN_METHODS` already includes `passkey`. `PRIVY_PASSKEY_LINK_ENABLED`
-controls authenticated account passkey enrollment independently from login
-methods. Passkey signup is not configurable and remains disabled so passkey
-authentication does not silently create a new account.
+Enabling passkey login requires `passkey` in `PRIVY_LOGIN_METHODS` (included in
+the backend default and `.env.example`). `PRIVY_PASSKEY_LOGIN_ENABLED` is an
+emergency kill switch for passkey login when `PRIVY_LOGIN_METHODS` already
+includes `passkey`. `PRIVY_PASSKEY_LINK_ENABLED` controls authenticated account
+passkey enrollment independently from login methods. Passkey signup is not
+configurable and remains disabled so passkey authentication does not silently
+create a new account.
 
 ## Privy wallet ownership boundary
 

--- a/src/api/auth/privy-auth.service.spec.ts
+++ b/src/api/auth/privy-auth.service.spec.ts
@@ -131,7 +131,7 @@ describe('PrivyAuthService account lifecycle', () => {
         expect(user.passkeyEnabled).toBe(true);
     });
 
-    it('repairs passkey-enabled state after a successful passkey login', async () => {
+    it('does not trust session authMethod to enable passkeys', async () => {
         const user = await AppUser.create({
             privyUserId: 'did:privy:user-1',
             status: 'active',
@@ -142,8 +142,11 @@ describe('PrivyAuthService account lifecycle', () => {
 
         await user.reload();
         expect(result.user.id).toBe(user.id);
-        expect(result.user.passkeyEnabled).toBe(true);
-        expect(user.passkeyEnabled).toBe(true);
+        expect(result.user.passkeyEnabled).toBe(false);
+        expect(user.passkeyEnabled).toBe(false);
+        expect(productEvents.recordBestEffort).not.toHaveBeenCalledWith(
+            expect.objectContaining({ eventName: 'account.login.passkey' }),
+        );
     });
 
     it('marks passkey enabled for an active account and records an audit event', async () => {

--- a/src/api/auth/privy-auth.service.ts
+++ b/src/api/auth/privy-auth.service.ts
@@ -59,7 +59,6 @@ export class PrivyAuthService {
 
         return this.sequelize.transaction(async (transaction) => {
             const now = new Date();
-            const passkeyAuthenticated = body.authMethod === 'passkey';
             let user = await AppUser.findOne({ where: { privyUserId: claims.sub }, transaction });
 
             if (user?.status === 'deleted') {
@@ -81,7 +80,7 @@ export class PrivyAuthService {
                     privyUserId: claims.sub,
                     email: body.email || claims.email || null,
                     authMethod: body.authMethod || null,
-                    passkeyEnabled: passkeyAuthenticated,
+                    passkeyEnabled: false,
                     status: 'active',
                 },
                 transaction,
@@ -93,7 +92,7 @@ export class PrivyAuthService {
                     email: body.email || claims.email || user.email || null,
                     authMethod: body.authMethod || user.authMethod || null,
                     status: 'active',
-                    passkeyEnabled: passkeyAuthenticated || user.passkeyEnabled,
+                    passkeyEnabled: user.passkeyEnabled,
                     deletedAt: null,
                     deletionRequestedAt: null,
                     deletionAvailableAt: null,
@@ -129,18 +128,6 @@ export class PrivyAuthService {
                     walletAttached: Boolean(body.wallet),
                 },
             });
-            if (passkeyAuthenticated) {
-                await this.productEvents.recordBestEffort({
-                    eventName: 'account.login.passkey',
-                    source: 'backend',
-                    status: 'succeeded',
-                    userId: user.id,
-                    sessionId: claims.sid,
-                    metadata: {
-                        accountCreated: created,
-                    },
-                });
-            }
 
             const wallets = await WalletLink.findAll({
                 where: { userId: user.id, status: 'active' },

--- a/src/api/auth/public-auth-config.service.spec.ts
+++ b/src/api/auth/public-auth-config.service.spec.ts
@@ -29,8 +29,8 @@ describe('PublicAuthConfigService', () => {
             enabled: true,
             provider: 'privy',
             privyAppId: 'privy-app-id',
-            loginMethods: ['email', 'google', 'apple'],
-            passkeyLoginEnabled: false,
+            loginMethods: ['email', 'google', 'apple', 'passkey'],
+            passkeyLoginEnabled: true,
             passkeySignupEnabled: false,
             passkeyLinkEnabled: true,
             walletOnboarding: {

--- a/src/api/auth/public-auth-config.service.ts
+++ b/src/api/auth/public-auth-config.service.ts
@@ -5,7 +5,7 @@ const PUBLIC_AUTH_LOGIN_METHODS = ['email', 'google', 'apple', 'passkey'] as con
 
 export type PublicAuthLoginMethod = (typeof PUBLIC_AUTH_LOGIN_METHODS)[number];
 
-const DEFAULT_PUBLIC_AUTH_LOGIN_METHODS: PublicAuthLoginMethod[] = ['email', 'google', 'apple'];
+const DEFAULT_PUBLIC_AUTH_LOGIN_METHODS: PublicAuthLoginMethod[] = ['email', 'google', 'apple', 'passkey'];
 
 export type PublicAuthConfig = {
     version: 1;


### PR DESCRIPTION
* feat(auth): enable passkey login in default public auth config

Include passkey in default PRIVY_LOGIN_METHODS so /api/v1/public/auth-config exposes passkeyLoginEnabled when Privy is configured, matching linked passkey enrollment already available in profile.

* fix(auth): do not trust session authMethod for passkeys

---------